### PR TITLE
1863 - Tela de atividade parlamentar detalhada

### DIFF
--- a/src/app/atividade-parlamentar/atividade-parlamentar-routing.module.ts
+++ b/src/app/atividade-parlamentar/atividade-parlamentar-routing.module.ts
@@ -2,11 +2,16 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { AtividadeParlamentarComponent } from './atividade-parlamentar.component';
+import { DetalhesParlamentarComponent } from './detalhes-parlamentar/detalhes-parlamentar.component';
 
 const routes: Routes = [
   {
     path: '',
     component: AtividadeParlamentarComponent
+  },
+  {
+    path: ':id',
+    component: DetalhesParlamentarComponent
   }
 ];
 

--- a/src/app/atividade-parlamentar/atividade-parlamentar.module.ts
+++ b/src/app/atividade-parlamentar/atividade-parlamentar.module.ts
@@ -5,11 +5,13 @@ import { AtividadeParlamentarRoutingModule } from './atividade-parlamentar-routi
 import { AtividadeParlamentarComponent } from './atividade-parlamentar.component';
 import { CardAtividadeComponent } from './card-atividade/card-atividade.component';
 import { SharedComponentsModule } from '../shared/components/shared-components.module';
+import { DetalhesParlamentarComponent } from './detalhes-parlamentar/detalhes-parlamentar.component';
 
 @NgModule({
   declarations: [
     AtividadeParlamentarComponent,
-    CardAtividadeComponent
+    CardAtividadeComponent,
+    DetalhesParlamentarComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -1,1 +1,22 @@
-<p>detalhes-parlamentar works!</p>
+<div class="cabecalho">
+  <div class="foto-parlamentar"><img [src]="urlFoto"></div>
+  <div class="titulo-parlamentar">
+    <div class="nome-parlamentar">{{ nome_autor }}</div>
+    <div class="partido-parlamentar">{{ partido }}/{{ uf }}</div>
+  </div>
+</div>
+
+<div class="card-detalhes card-peso-politico">
+  <h3 class="card-titulo">Peso Político</h3>
+  <div class="card-corpo"></div>
+</div>
+
+<div class="card-detalhes card-papeis-importantes">
+  <h3 class="card-titulo">Papéis Importantes</h3>
+  <div class="card-corpo"></div>
+</div>
+
+<div class="card-detalhes card-atividade-congresso">
+  <h3 class="card-titulo">Atividade No Congresso</h3>
+  <div class="card-corpo"></div>
+</div>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -1,0 +1,1 @@
+<p>detalhes-parlamentar works!</p>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -3,8 +3,8 @@
     <img [src]="urlFoto">
   </div>
   <div class="titulo-parlamentar align-self-center">
-    <h4>{{ nome_autor }}</h4>
-    <span class="text-muted">{{ partido }}/{{ uf }}</span>
+    <h4>{{ parlamentar.nome_autor }}</h4>
+    <span class="text-muted">{{ parlamentar.partido }}/{{ parlamentar.uf }}</span>
   </div>
 </div>
 <div class="container">

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -1,22 +1,27 @@
-<div class="cabecalho">
-  <div class="foto-parlamentar"><img [src]="urlFoto"></div>
-  <div class="titulo-parlamentar">
-    <div class="nome-parlamentar">{{ nome_autor }}</div>
-    <div class="partido-parlamentar">{{ partido }}/{{ uf }}</div>
+<div class="cabecalho d-flex justify-content-center">
+  <div class="foto-parlamentar col-sm-1 col-md-1">
+    <img [src]="urlFoto">
+  </div>
+  <div class="titulo-parlamentar align-self-center">
+    <h4>{{ nome_autor }}</h4>
+    <span class="text-muted">{{ partido }}/{{ uf }}</span>
   </div>
 </div>
+<div class="container">
+  <div class="card-detalhes card-peso-politico">
+    <h3 class="card-titulo">Peso Político</h3>
+    <div class="card-corpo">
+      <app-avaliacao nivel="Conhecida" valor="1" ehGrande=true></app-avaliacao>
+    </div>
+  </div>
 
-<div class="card-detalhes card-peso-politico">
-  <h3 class="card-titulo">Peso Político</h3>
-  <div class="card-corpo"></div>
-</div>
+  <div class="card-detalhes card-papeis-importantes">
+    <h3 class="card-titulo">Papéis Importantes</h3>
+    <div class="card-corpo"></div>
+  </div>
 
-<div class="card-detalhes card-papeis-importantes">
-  <h3 class="card-titulo">Papéis Importantes</h3>
-  <div class="card-corpo"></div>
-</div>
-
-<div class="card-detalhes card-atividade-congresso">
-  <h3 class="card-titulo">Atividade No Congresso</h3>
-  <div class="card-corpo"></div>
+  <div class="card-detalhes card-atividade-congresso">
+    <h3 class="card-titulo">Atividade No Congresso</h3>
+    <div class="card-corpo"></div>
+  </div>
 </div>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
@@ -1,8 +1,6 @@
 $base-color: #20201e;
 
 .cabecalho {
-  border-bottom: solid 2px #20201e;
-  margin-bottom: 0.5rem;
   display: flex;
   flex-wrap: wrap;
 }

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
@@ -3,6 +3,25 @@ $base-color: #20201e;
 .cabecalho {
   border-bottom: solid 2px #20201e;
   margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.foto-parlamentar {
+  border: solid 1.5px #20201e;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+  padding: 0.5px;
+  width: 25%;
+}
+
+.foto-parlamentar > img {
+  width: 100%;
+}
+
+.titulo-parlamentar {
+  margin-left: 0.5rem;
 }
 
 .card-detalhes {

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.scss
@@ -1,0 +1,17 @@
+$base-color: #20201e;
+
+.cabecalho {
+  border-bottom: solid 2px #20201e;
+  margin-bottom: 0.5rem;
+}
+
+.card-detalhes {
+  border: solid 1.5px $base-color;
+  margin-bottom: 0.5rem;
+  padding: 5px;
+}
+
+.card-detalhes > .card-titulo {
+  font-size: 1.3rem;
+  font-weight: 400;
+}

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.spec.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DetalhesParlamentarComponent } from './detalhes-parlamentar.component';
+
+describe('DetalhesParlamentarComponent', () => {
+  let component: DetalhesParlamentarComponent;
+  let fixture: ComponentFixture<DetalhesParlamentarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DetalhesParlamentarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DetalhesParlamentarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-detalhes-parlamentar',
+  templateUrl: './detalhes-parlamentar.component.html',
+  styleUrls: ['./detalhes-parlamentar.component.scss']
+})
+export class DetalhesParlamentarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.ts
@@ -7,9 +7,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class DetalhesParlamentarComponent implements OnInit {
 
+  urlFoto: string;
+  nome_autor: string;
+  partido: string;
+  uf: string;
+
   constructor() { }
 
   ngOnInit(): void {
+    const id_autor = 107283;
+    this.urlFoto = `https://www.camara.leg.br/internet/deputado/bandep/${id_autor}.jpg`;
+    this.nome_autor = 'Dep. Gleisi Hoffmann';
+    this.partido = 'PT';
+    this.uf = 'PR';
   }
 
 }

--- a/src/app/shared/components/avaliacao/avaliacao.component.html
+++ b/src/app/shared/components/avaliacao/avaliacao.component.html
@@ -1,8 +1,9 @@
-<div class="avaliacao">
+<div class="avaliacao d-flex align-items-center">
   <span class="avaliacao-label" [hidden]="!exibirLabel">Peso</span>
-  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 0}"></span>
-  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 1}"></span>
-  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 2}"></span>
-  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 3}"></span>
-  <span class="avaliacao-bloco ultimo" [ngClass]="{'checked': valor > 4}"></span>
+  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 0, 'bloco-grande': ehGrande}"></span>
+  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 1, 'bloco-grande': ehGrande}"></span>
+  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 2, 'bloco-grande': ehGrande}"></span>
+  <span class="avaliacao-bloco" [ngClass]="{'checked': valor > 3, 'bloco-grande': ehGrande}"></span>
+  <span class="avaliacao-bloco ultimo" [ngClass]="{'checked': valor > 4, 'bloco-grande': ehGrande}"></span>
+  <span class="avaliacao-nivel" [hidden]="!nivel">({{ nivel }})</span>
 </div>

--- a/src/app/shared/components/avaliacao/avaliacao.component.scss
+++ b/src/app/shared/components/avaliacao/avaliacao.component.scss
@@ -1,15 +1,25 @@
 $base-color: #20201e;
 
+.avaliacao {
+  margin-top: 5px;
+}
+
 .avaliacao-label {
   margin-right: 0.5rem;
 }
 
 .avaliacao-bloco {
   border: solid 1px $base-color;
+  display: inline-block;
   width: 14px;
   height: 14px;
-  display: inline-block;
   margin-right: 2px;
+}
+
+.bloco-grande {
+  width: 30px;
+  height: 30px;
+  margin-right: 5px;
 }
 
 .ultimo {
@@ -18,4 +28,8 @@ $base-color: #20201e;
 
 .checked {
   background-color: $base-color;
+}
+
+.avaliacao-nivel {
+  margin-left: 7px;
 }

--- a/src/app/shared/components/avaliacao/avaliacao.component.ts
+++ b/src/app/shared/components/avaliacao/avaliacao.component.ts
@@ -10,6 +10,8 @@ export class AvaliacaoComponent implements OnInit {
   @Input() label: string;
   @Input() valor: number;
   @Input() exibirLabel: boolean;
+  @Input() nivel: string;
+  @Input() ehGrande: boolean;
 
   constructor() { }
 

--- a/src/app/shared/models/ator.model.ts
+++ b/src/app/shared/models/ator.model.ts
@@ -1,9 +1,11 @@
 
 export interface Ator {
   id_autor: number;
+  id_ext: number;
   nome_autor: string;
   partido: string;
   uf: string;
+  casa: string;
   peso_total_documentos: number;
   num_documentos: number;
   tipo_generico: string;

--- a/src/app/shared/services/ator.service.ts
+++ b/src/app/shared/services/ator.service.ts
@@ -15,7 +15,8 @@ import { environment } from '../../../environments/environment';
 })
 export class AtorService {
 
-  private atorUrl = `${environment.baseUrl}/atores`;
+  private atorUrl = `${environment.baseUrl}/ator`;
+  private atoresUrl = `${environment.baseUrl}/atores`;
   private autoriaUrl = `${environment.baseUrl}/autorias`;
 
   constructor(private http: HttpClient) { }
@@ -24,17 +25,21 @@ export class AtorService {
     return this.http.get<Proposicao[]>(`${environment.baseUrl}/proposicoes`);
   }
 
+  getAtor(idAtor: string): Observable<Ator> {
+    return this.http.get<Ator>(`${this.atorUrl}/${idAtor}`);
+  }
+
   getAtores(): any[] {
     const proposicoes: any = this.getProposicoes();
     const atores = [];
     proposicoes.forEach(proposicao => {
-        atores.push(this.http.get<Ator>(`${this.atorUrl}/${proposicao.id_leggo}`));
+        atores.push(this.http.get<Ator>(`${this.atoresUrl}/${proposicao.id_leggo}`));
     });
     return atores;
   }
 
   getAtoresAgregados(interesse: string): Observable<AtorAgregado[]> {
-    return this.http.get<AtorAgregado[]>(`${this.atorUrl}/agregados?interesse=${interesse}`);
+    return this.http.get<AtorAgregado[]>(`${this.atoresUrl}/agregados?interesse=${interesse}`);
   }
 
   getAutoriasAgregadas(interesse: string): Observable<AutoriaAgregada[]> {


### PR DESCRIPTION
Cria esqueleto da tela de atividade parlamentar detalhada e exibe informações como nome, partido e UF.

A foto só está funcionando para deputados. O id para obter fotos de senadores ainda não está sendo retornado pelo backend.

O card de peso parlamentar ainda não possui dados reais.