### PR TITLE
Adiciona cards para todos os parlamentares em exercício

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { PesoPoliticoService } from './shared/services/peso-politico.service';
 import { RelatoriaService } from './shared/services/relatoria.service';
 import { ParlamentaresService } from './shared/services/parlamentares.service';
 import { ParlamentarDetalhadoService } from './shared/services/parlamentar-detalhado.service';
+import { EntidadeService } from './shared/services/entidade.service';
 
 
 @NgModule({
@@ -34,7 +35,8 @@ import { ParlamentarDetalhadoService } from './shared/services/parlamentar-detal
     PesoPoliticoService,
     RelatoriaService,
     ParlamentaresService,
-    ParlamentarDetalhadoService
+    ParlamentarDetalhadoService,
+    EntidadeService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/shared/models/entidade.model.ts
+++ b/src/app/shared/models/entidade.model.ts
@@ -1,0 +1,8 @@
+
+export interface Entidade {
+  id_autor_parlametria: string;
+  casa_autor: string;
+  nome_autor: string;
+  partido: string;
+  uf: string;
+}

--- a/src/app/shared/services/entidade.service.spec.ts
+++ b/src/app/shared/services/entidade.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EntidadeService } from './entidade.service';
+
+describe('EntidadeService', () => {
+  let service: EntidadeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EntidadeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/entidade.service.ts
+++ b/src/app/shared/services/entidade.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+
+import { environment } from 'src/environments/environment';
+import { Entidade } from '../models/entidade.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EntidadeService {
+
+  private entidadeUrl = `${environment.baseUrl}/entidades`;
+
+  constructor(private http: HttpClient) { }
+
+  getParlamentaresExercicio(): Observable<Entidade[]> {
+    return this.http.get<Entidade[]>(`${this.entidadeUrl}/parlamentares/exercicio`);
+  }
+
+}


### PR DESCRIPTION
## Mudanças 
- Adiciona cards para todos os parlamentares em exercício e não somente aqueles que tem atuação na agenda
- Adiciona o serviço de entidades
- Adiciona processamento para considerar todos os parlamentares em
- exercício no momento de montar os dados de parlamentares
- Corrige função de ordenação
- Adiciona model para entidades

## Flags
- Depende da versão do backend https://github.com/parlametria/leggo-backend/pull/231