### PR TITLE
Ajusta formatação dos pesos de atuação parlamentar (no texto)

### DIFF
--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
@@ -74,7 +74,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
         this.infoTexto = '';
         const autoriasPorTipo = d3.group(autoriasApresentadas, d => d.tipo_documento);
         autoriasPorTipo.forEach((documento, tipo) => {
-          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} foram ${this.formataTipo(tipo, documento)}`;
+          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} ${this.formataTipo(tipo, documento)}`;
         });
       });
   }
@@ -92,12 +92,23 @@ export class AtividadeNoCongressoComponent implements OnInit {
   }
 
   private formataTipo(tipo, documento): string {
-    let plural = tipo.toLowerCase();
-    if (plural === 'prop. original / apensada') {
-      plural = 'props. originais / apensadas';
+    const peso = this.somaPesos(documento);
+    let tipoFormatado = tipo.toLowerCase();
+    const isPlural = peso > 1;
+
+    if (tipoFormatado === 'prop. original / apensada') {
+      if (isPlural) {
+        tipoFormatado = 'foi proposição original ou apensada';
+      } else {
+        tipoFormatado = 'foram proposições originais ou apensadas';
+      }
     } else {
-      plural = plural + 's';
+      if (isPlural) {
+        tipoFormatado = 'foram ' + tipoFormatado + 's';
+      } else {
+        tipoFormatado = 'foi ' + tipoFormatado;
+      }
     }
-    return plural;
+    return tipoFormatado;
   }
 }

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
@@ -74,7 +74,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
         this.infoTexto = '';
         const autoriasPorTipo = d3.group(autoriasApresentadas, d => d.tipo_documento);
         autoriasPorTipo.forEach((documento, tipo) => {
-          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} foram do tipo ${tipo.toLowerCase()}`;
+          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} foram ${this.formataTipo(tipo, documento)}`;
         });
       });
   }
@@ -89,5 +89,15 @@ export class AtividadeNoCongressoComponent implements OnInit {
 
   private formataPesos(peso): number {
     return peso <= 1 && peso >= 0.01 ? peso.toFixed(2) : peso.toFixed(0);
+  }
+
+  private formataTipo(tipo, documento): string {
+    let plural = tipo.toLowerCase();
+    if (plural === 'prop. original / apensada') {
+      plural = 'props. originais / apensadas';
+    } else {
+      plural = plural + 's';
+    }
+    return plural;
   }
 }

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
@@ -74,7 +74,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
         this.infoTexto = '';
         const autoriasPorTipo = d3.group(autoriasApresentadas, d => d.tipo_documento);
         autoriasPorTipo.forEach((documento, tipo) => {
-          this.infoTexto += `, ${this.somaPesos(documento).toFixed(0)} foram ${tipo}`;
+          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} foram do tipo ${tipo.toLowerCase()}`;
         });
       });
   }
@@ -85,5 +85,9 @@ export class AtividadeNoCongressoComponent implements OnInit {
       pesoTotal += doc.peso_autor_documento;
     });
     return pesoTotal;
+  }
+
+  private formataPesos(peso): number {
+    return peso <= 1 && peso >= 0.01 ? peso.toFixed(2) : peso.toFixed(0);
   }
 }

--- a/src/app/shared/services/twitter.service.ts
+++ b/src/app/shared/services/twitter.service.ts
@@ -10,7 +10,7 @@ import { environment } from 'src/environments/environment';
 })
 export class TwitterService {
 
-  private twitterUrl = `${environment.twitterAPIUrl}/tweets`;
+  private twitterUrl = `${environment.twitterAPIUrl}/api/tweets`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   baseUrl: 'https://dev.api.leggo.org.br',
-  twitterAPIUrl: 'https://leggo-twitter.herokuapp.com'
+  twitterAPIUrl: 'https://leggo-twitter-validacao.herokuapp.com'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   baseUrl: 'http://localhost:8000',
-  twitterAPIUrl: 'http://localhost:5001/api'
+  twitterAPIUrl: 'http://localhost:5001'
 };
 
 /*


### PR DESCRIPTION
**Mudanças neste PR:**

- Modifica formatação dos pesos: se for entre 0.01 até 0.99, exiba neste formato; do contrário, retire as casas decimais;
- Modifica texto, adicionando 'do tipo' e colocando os tipos para lowercase.