### PR TITLE
2163 - Atualiza crachás

### DIFF
--- a/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
+++ b/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
@@ -25,9 +25,9 @@
     </div>
     <div class="insignias">
       <div>
-        <span *ngIf="parlamentar.quantidade_autorias">
+        <span *ngIf="parlamentar.quant_autorias_projetos">
           <span class="icon-autor app-icon text-danger"></span>
-          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.quantidade_autorias }}</span>
+          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.quant_autorias_projetos }}</span>
         </span>
 
         <span *ngIf="parlamentar.quantidade_relatorias">

--- a/src/app/shared/models/atorAgregado.model.ts
+++ b/src/app/shared/models/atorAgregado.model.ts
@@ -13,6 +13,7 @@ export interface AtorAgregado {
   quantidade_autorias: number;
   quantidade_comissao_presidente: number;
   quantidade_relatorias: number;
+  quant_autorias_projetos: number;
   peso_politico: number;
   nome_processado: string;
   indice: number;

--- a/src/app/shared/services/autorias.service.ts
+++ b/src/app/shared/services/autorias.service.ts
@@ -37,4 +37,7 @@ export class AutoriasService {
     return this.http.get<Autoria[]>(`${this.atorUrl}/${idAtor}/originais/?interesse=${interesse}&tema=${tema}`);
   }
 
+  getAutoriasAgregadasProjetos(interesse: string, tema: string): Observable<Autoria[]> {
+    return this.http.get<Autoria[]>(`${this.autoriaUrl}/projetos/?interesse=${interesse}&tema=${tema}`);
+  }
 }

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -83,7 +83,8 @@ export class ParlamentaresService {
         this.comissaoService.getComissaoPresidencia(interesse, tema),
         this.relatoriaService.getAtoresRelatores(interesse, tema),
         this.pesoService.getPesoPolitico(),
-        this.twitterService.getAtividadeTwitter(interesse, tema)
+        this.twitterService.getAtividadeTwitter(interesse, tema),
+        this.autoriaService.getAutoriasAgregadasProjetos(interesse, tema)
       ]
     )
       .subscribe(data => {
@@ -94,6 +95,7 @@ export class ParlamentaresService {
         const atoresRelatores: any = data[4];
         const pesoPolitico: any = data[5];
         const twitter: any = data[6];
+        const autoriasProjetos: any = data[7];
 
         const parlamentares = parlamentaresExercicio.map(a => ({
           ...atores.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
@@ -102,6 +104,7 @@ export class ParlamentaresService {
           ...atoresRelatores.find(p => a.id_autor_parlametria === p.autor_id_parlametria),
           ...pesoPolitico.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
           ...twitter.find(p => a.id_autor_parlametria === +p.id_parlamentar_parlametria),
+          ...autoriasProjetos.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
           ...a
         }));
 


### PR DESCRIPTION
Atualiza número de autorias nos crachás, considerando somente autorias do tipo_documento = 'Prop. Original / Apensada'.

Deve está na branch [2163-criar-endpoint-autoria](https://github.com/parlametria/leggo-backend/pull/272) do backend.