### PR TITLE
Fix cracha autorias

### DIFF
--- a/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
+++ b/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
@@ -37,16 +37,16 @@
       <div>
         <span
           class="cracha"
-          *ngIf="parlamentar.quant_autorias_projetos"
+          *ngIf="parlamentar.peso_autorias_projetos"
           [ngbPopover]="popAutorias"
           [autoClose]="'outside'">
           <span class="icon-autor app-icon text-danger"></span>
-          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.quant_autorias_projetos }}</span>
+          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.peso_autorias_projetos }}</span>
           <ng-template #popAutorias>
             <strong>Autor</strong>
-            &nbsp;de {{ parlamentar.quant_autorias_projetos }}
-            <span *ngIf="parlamentar.quant_autorias_projetos === 1">&nbsp;proposição</span>
-            <span *ngIf="parlamentar.quant_autorias_projetos !== 1">&nbsp;proposições</span>
+            &nbsp;de {{ parlamentar.peso_autorias_projetos }}
+            <span *ngIf="parlamentar.peso_autorias_projetos === 1">&nbsp;proposição</span>
+            <span *ngIf="parlamentar.peso_autorias_projetos !== 1">&nbsp;proposições</span>
             <div class="text-right">
               <a [routerLink]="[parlamentar.id_autor_parlametria + '/papeis']" class="btn btn-link btn-sm">+ Detalhes</a>
             </div>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
@@ -90,7 +90,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
   }
 
   private formataPesos(peso): number {
-    return peso < 1 && peso >= 0.01 ? peso.toFixed(2) : peso.toFixed(0);
+    return peso % 1 !== 0 ? peso.toFixed(2) : peso;
   }
 
   private formataTipo(tipo, documento): string {

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -54,14 +54,14 @@
           <div>
             <span
               class="cracha"
-              *ngIf="parlamentar?.autorias?.length"
+              *ngIf="parlamentar?.total_peso_autorias"
               [ngbPopover]="popAutorias"
               [autoClose]="'outside'">
               <span class="icon-autor app-icon text-danger"></span>
-              <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar?.autorias?.length }}</span>
+              <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar?.total_peso_autorias }}</span>
               <ng-template #popAutorias>
                 <strong>Autor</strong>
-                &nbsp;de {{ parlamentar?.autorias?.length }}
+                &nbsp;de {{ parlamentar?.total_peso_autorias }}
                 <span *ngIf="parlamentar?.autorias?.length === 1">&nbsp;proposição</span>
                 <span *ngIf="parlamentar?.autorias?.length !== 1">&nbsp;proposições</span>
                 <div class="text-right">

--- a/src/app/shared/models/atorAgregado.model.ts
+++ b/src/app/shared/models/atorAgregado.model.ts
@@ -14,6 +14,7 @@ export interface AtorAgregado {
   quantidade_comissao_presidente: number;
   quantidade_relatorias: number;
   quant_autorias_projetos: number;
+  peso_autorias_projetos: number;
   peso_politico: number;
   nome_processado: string;
   indice: number;

--- a/src/app/shared/models/atorDetalhado.model.ts
+++ b/src/app/shared/models/atorDetalhado.model.ts
@@ -16,4 +16,5 @@ export interface AtorDetalhado {
     autorias: Autoria[];
     atividadeParlamentar: any;
     atividadeTwitter: any;
+    total_peso_autorias: number;
 }

--- a/src/app/shared/services/parlamentar-detalhado.service.ts
+++ b/src/app/shared/services/parlamentar-detalhado.service.ts
@@ -57,7 +57,7 @@ export class ParlamentarDetalhadoService {
           atividadeTwitter.max_atividade_twitter
         );
 
-        const peso_total_autorias = this.calculaPesoTotalAutorias(autorias);
+        const pesoTotalAutorias = this.calculaPesoTotalAutorias(autorias);
 
         const parlamentarDetalhado = ator;
         parlamentarDetalhado.autorias = autorias;
@@ -65,7 +65,7 @@ export class ParlamentarDetalhadoService {
         parlamentarDetalhado.comissoes = comissoesInfo;
         parlamentarDetalhado.atividadeParlamentar = atividadeParlamentar;
         parlamentarDetalhado.atividadeTwitter = atividadeTwitter;
-        parlamentarDetalhado.total_peso_autorias = peso_total_autorias;
+        parlamentarDetalhado.total_peso_autorias = pesoTotalAutorias;
 
         this.parlamentarDetalhado.next(parlamentarDetalhado);
       },
@@ -96,8 +96,9 @@ export class ParlamentarDetalhadoService {
   }
 
   private calculaPesoTotalAutorias(autorias: Autoria[]): number {
-    let peso_total_autorias = autorias.reduce((a, b) => a + b.peso_autor_documento, 0);
-    return +peso_total_autorias.toFixed(2);
+    let pesoTotalAutorias = autorias.reduce((a, b) => a + b.peso_autor_documento, 0);
+    pesoTotalAutorias = +pesoTotalAutorias;
+    return pesoTotalAutorias % 1 !== 0 ? +pesoTotalAutorias.toFixed(2) : pesoTotalAutorias;
   }
 
 }

--- a/src/app/shared/services/parlamentar-detalhado.service.ts
+++ b/src/app/shared/services/parlamentar-detalhado.service.ts
@@ -9,6 +9,7 @@ import { AutoriasService } from 'src/app/shared/services/autorias.service';
 import { AtorDetalhado } from '../models/atorDetalhado.model';
 import { AtorService } from './ator.service';
 import { TwitterService } from 'src/app/shared/services/twitter.service';
+import { Autoria } from '../models/autoria.model';
 
 @Injectable({
   providedIn: 'root'
@@ -56,12 +57,15 @@ export class ParlamentarDetalhadoService {
           atividadeTwitter.max_atividade_twitter
         );
 
+        const peso_total_autorias = this.calculaPesoTotalAutorias(autorias);
+
         const parlamentarDetalhado = ator;
         parlamentarDetalhado.autorias = autorias;
         parlamentarDetalhado.relatorias = relatorias;
         parlamentarDetalhado.comissoes = comissoesInfo;
         parlamentarDetalhado.atividadeParlamentar = atividadeParlamentar;
         parlamentarDetalhado.atividadeTwitter = atividadeTwitter;
+        parlamentarDetalhado.total_peso_autorias = peso_total_autorias;
 
         this.parlamentarDetalhado.next(parlamentarDetalhado);
       },
@@ -89,6 +93,11 @@ export class ParlamentarDetalhadoService {
 
   private normalizarAtividade(metrica: number, min: number, max: number): number {
     return (metrica - min) / (max - min);
+  }
+
+  private calculaPesoTotalAutorias(autorias: Autoria[]): number {
+    let peso_total_autorias = autorias.reduce((a, b) => a + b.peso_autor_documento, 0);
+    return +peso_total_autorias.toFixed(2);
   }
 
 }

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -135,6 +135,13 @@ export class ParlamentaresService {
           p.atividade_parlamentar = this.normalizarAtividade(p.peso_documentos, p.min_peso_documentos, p.max_peso_documentos);
           p.atividade_twitter = this.normalizarAtividade(p.atividade_twitter, Math.min(...tweets), Math.max(...tweets));
           p.peso_politico = this.pesoService.normalizarPesoPolitico(p.peso_politico, Math.max(...pesosPoliticos));
+          if (p.peso_autorias_projetos) {
+            if (p.peso_autorias_projetos % 1 !== 0) {
+              p.peso_autorias_projetos = +p.peso_autorias_projetos.toFixed(2);
+            }
+          } else {
+            p.peso_autorias_projetos = 0;
+          }
         });
 
         this.parlamentares.next(parlamentares);


### PR DESCRIPTION
Fixes #128 

**Mudanças neste PR:**

- Adiciona campo de peso total de autorias nos models AtorAgregado e AtorDetalhado;
- Modifica a exibição do número de autorias para peso total de autorias;
- Modifica arredondamento para 2 casas decimais caso o peso seja decimal.


**OBS:** É necessário que o back-end esteja na versão da branch `fix-cracha-autorias`.