### PR TITLE
Troca peso por quantidade documentos

### DIFF
--- a/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
+++ b/src/app/atividade-parlamentar/card-atividade/card-atividade.component.html
@@ -37,16 +37,16 @@
       <div>
         <span
           class="cracha"
-          *ngIf="parlamentar.peso_autorias_projetos"
+          *ngIf="parlamentar.quant_autorias_projetos"
           [ngbPopover]="popAutorias"
           [autoClose]="'outside'">
           <span class="icon-autor app-icon text-danger"></span>
-          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.peso_autorias_projetos }}</span>
+          <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar.quant_autorias_projetos }}</span>
           <ng-template #popAutorias>
             <strong>Autor</strong>
-            &nbsp;de {{ parlamentar.peso_autorias_projetos }}
-            <span *ngIf="parlamentar.peso_autorias_projetos === 1">&nbsp;proposição</span>
-            <span *ngIf="parlamentar.peso_autorias_projetos !== 1">&nbsp;proposições</span>
+            &nbsp;de {{ parlamentar.quant_autorias_projetos }}
+            <span *ngIf="parlamentar.quant_autorias_projetos === 1">&nbsp;proposição</span>
+            <span *ngIf="parlamentar.quant_autorias_projetos !== 1">&nbsp;proposições</span>
             <div class="text-right">
               <a [routerLink]="[parlamentar.id_autor_parlametria + '/papeis']" class="btn btn-link btn-sm">+ Detalhes</a>
             </div>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.html
@@ -23,7 +23,7 @@
   <div *ngIf="parlamentar?.ranking_documentos">
     {{ parlamentar?.ranking_documentos }}° parlamentar mais atuante neste painel e tema.
     <div class="titulo">
-      Das {{ parlamentar?.peso_total }} ações{{ infoTexto }}.
+      Das {{ totalDocs }} ações{{ infoTexto }}.
     </div>
   </div>
   <h3 *ngIf="parlamentar" class="titulo-sessao mt-3">Por Proposição</h3>

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/atividade-no-congresso/atividade-no-congresso.component.ts
@@ -23,6 +23,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
   public tema: string;
   public parlamentar: any;
   public infoTexto: string;
+  public totalDocs: number;
   public isLoading = new BehaviorSubject<boolean>(true);
 
   constructor(
@@ -54,7 +55,7 @@ export class AtividadeNoCongressoComponent implements OnInit {
         if (dado.tipo_acao === 'Proposição') {
           if (dado.id_autor_parlametria.toString() === idAtor.toString()) {
             this.parlamentar = dado;
-            this.parlamentar.peso_total = this.parlamentar.peso_total.toFixed(0);
+            this.parlamentar.peso_total = +this.parlamentar.peso_total;
             return;
           }
         }
@@ -74,29 +75,19 @@ export class AtividadeNoCongressoComponent implements OnInit {
           }
         });
         this.infoTexto = '';
+        this.totalDocs = 0;
         const autoriasPorTipo = d3.group(autoriasApresentadas, d => d.tipo_documento);
         autoriasPorTipo.forEach((documento, tipo) => {
-          this.infoTexto += `, ${this.formataPesos(this.somaPesos(documento))} ${this.formataTipo(tipo, documento)}`;
+          this.infoTexto += `, ${documento.length} ${this.formataTipo(tipo, documento)}`;
+          this.totalDocs += documento.length;
         });
       });
   }
 
-  private somaPesos(documento): number {
-    let pesoTotal = 0;
-    documento.forEach(doc => {
-      pesoTotal += doc.peso_autor_documento;
-    });
-    return pesoTotal;
-  }
-
-  private formataPesos(peso): number {
-    return peso % 1 !== 0 ? peso.toFixed(2) : peso;
-  }
-
   private formataTipo(tipo, documento): string {
-    const peso = this.somaPesos(documento);
+    const docs = documento.length;
     let tipoFormatado = tipo.toLowerCase();
-    const isPlural = peso.toFixed(0) !== '1';
+    const isPlural = docs > 1;
 
     if (tipoFormatado === 'prop. original / apensada') {
       if (!isPlural) {

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/detalhes-parlamentar.component.html
@@ -54,14 +54,14 @@
           <div>
             <span
               class="cracha"
-              *ngIf="parlamentar?.total_peso_autorias"
+              *ngIf="parlamentar?.autorias?.length"
               [ngbPopover]="popAutorias"
               [autoClose]="'outside'">
               <span class="icon-autor app-icon text-danger"></span>
-              <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar?.total_peso_autorias }}</span>
+              <span class="badge badge-danger app-badge badge-color-white">{{ parlamentar?.autorias?.length }}</span>
               <ng-template #popAutorias>
                 <strong>Autor</strong>
-                &nbsp;de {{ parlamentar?.total_peso_autorias }}
+                &nbsp;de {{ parlamentar?.autorias?.length }}
                 <span *ngIf="parlamentar?.autorias?.length === 1">&nbsp;proposição</span>
                 <span *ngIf="parlamentar?.autorias?.length !== 1">&nbsp;proposições</span>
                 <div class="text-right">

--- a/src/app/atividade-parlamentar/detalhes-parlamentar/vis-atividade-detalhada/vis-atividade-detalhada.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/vis-atividade-detalhada/vis-atividade-detalhada.component.ts
@@ -94,7 +94,7 @@ export class VisAtividadeDetalhadaComponent implements OnInit {
         tipos.push({
           titulo: tipo,
           id: idLeggo,
-          value: parseFloat(this.somaPesos(documento).toFixed(2)),
+          value: documento.length,
           quantidade: documento.length,
           categoria: tipo
         });

--- a/src/app/shared/services/parlamentar-detalhado.service.ts
+++ b/src/app/shared/services/parlamentar-detalhado.service.ts
@@ -47,9 +47,9 @@ export class ParlamentarDetalhadoService {
 
         const comissoesInfo = this.getComissoesProcessadas(comissoesPresidencia);
         atividadeParlamentar.atividade_parlamentar = this.normalizarAtividade(
-          atividadeParlamentar.peso_documentos,
-          atividadeParlamentar.min_peso_documentos,
-          atividadeParlamentar.max_peso_documentos);
+          atividadeParlamentar.quantidade_autorias,
+          atividadeParlamentar.min_quantidade_autorias,
+          atividadeParlamentar.max_quantidade_autorias);
 
         atividadeTwitter.atividade_twitter = this.normalizarAtividade(
           atividadeTwitter.atividade_twitter,

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -132,7 +132,7 @@ export class ParlamentaresService {
 
         parlamentares.forEach(p => {
           p.nome_processado = p.nome_autor.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-          p.atividade_parlamentar = this.normalizarAtividade(p.peso_documentos, p.min_peso_documentos, p.max_peso_documentos);
+          p.atividade_parlamentar = this.normalizarAtividade(p.quantidade_autorias, p.min_quantidade_autorias, p.max_quantidade_autorias);
           p.atividade_twitter = this.normalizarAtividade(p.atividade_twitter, Math.min(...tweets), Math.max(...tweets));
           p.peso_politico = this.pesoService.normalizarPesoPolitico(p.peso_politico, Math.max(...pesosPoliticos));
           if (p.peso_autorias_projetos) {


### PR DESCRIPTION
Adapta números do painel para refletir quantidade de documentos.

Alterações dependem da branch do [backend](https://github.com/parlametria/leggo-backend/pull/292).
Fixes [#137](https://github.com/parlametria/leggo-painel/issues/137).