### PR TITLE
Remove parâmetros não mais utilizados pelos endpoints de média e engajamento

### DIFF
--- a/src/app/atividade-parlamentar/detalhes-parlamentar/vis-atividade-twitter/vis-atividade-twitter.component.ts
+++ b/src/app/atividade-parlamentar/detalhes-parlamentar/vis-atividade-twitter/vis-atividade-twitter.component.ts
@@ -106,9 +106,9 @@ export class VisAtividadeTwitterComponent implements OnInit {
   private carregarVis() {
     forkJoin([
       this.entidadeService.getParlamentaresExercicio(''),
-      this.twitterService.getMediaTweets(this.interesse, this.tema),
+      this.twitterService.getMediaTweets(),
       this.twitterService.getPercentualTweets(this.interesse, this.tema),
-      this.twitterService.getEngajamento(this.interesse, this.tema)
+      this.twitterService.getEngajamento()
     ]).subscribe(data => {
       const parlamentaresExercicio: any = data[0];
       const mediaTweets: any = data[1];
@@ -229,8 +229,8 @@ export class VisAtividadeTwitterComponent implements OnInit {
     return `<p class="vis-tooltip-titulo"><strong>${d.nome_autor}</strong> ${d.partido}/${d.uf}</p>
     <p><strong>${(d.atividade_twitter)}</strong> tweets no período</p>
     <p><strong>${format('.2%')(d.percentual_atividade_twitter)}</strong> de seus tweets são sobre o tema</p>
-    <p><strong>${format('.1')(d.media_tweets)}</strong> tweets por mês</p>
-    <p><strong>${format('.2f')(d.engajamento)}</strong> curtidas, respostas e retweets em média</p>`;
+    <p><strong>${format('.1f')(d.media_tweets)}</strong> tweets por mês</p>
+    <p><strong>${format('.1f')(d.engajamento)}</strong> curtidas, respostas e retweets em média</p>`;
   }
 
 }

--- a/src/app/shared/services/twitter.service.ts
+++ b/src/app/shared/services/twitter.service.ts
@@ -30,12 +30,10 @@ export class TwitterService {
     return this.http.get<any>(`${this.twitterUrl}/tweets/parlamentares/${id}`, { params });
   }
 
-  getMediaTweets(interesse: string, tema: string): Observable<any> {
+  getMediaTweets(): Observable<any> {
     const params = new HttpParams()
-      .set('interesse', interesse)
-      .set('tema', tema)
-      .set('data_inicial', '01-01-2000')
-      .set('data_final', '10-10-2020');
+      .set('data_inicial', '2000-01-01')
+      .set('data_final', '2020-12-31');
     return this.http.get<any>(`${this.twitterUrl}/parlamentares/media`, { params });
   }
 
@@ -48,12 +46,10 @@ export class TwitterService {
     return this.http.get<any>(`${this.twitterUrl}/parlamentares/percentual_atividade_agenda`, { params });
   }
 
-  getEngajamento(interesse: string, tema: string): Observable<any> {
+  getEngajamento(): Observable<any> {
     const params = new HttpParams()
-      .set('interesse', interesse)
-      .set('tema', tema)
-      .set('data_inicial', '01-01-2000')
-      .set('data_final', '10-10-2020');
+      .set('data_inicial', '2000-01-01')
+      .set('data_final', '2020-12-31');
     return this.http.get<any>(`${this.twitterUrl}/parlamentares/engajamento`, { params });
   }
 


### PR DESCRIPTION
## Mudanças
- Remove parâmetros não mais utilizados pelos endpoints de média e engajamento. Assume que o cálculo do engajamento e da média não mais considera o agenda e a tema, passando a considerar todos os tweets dos parlamentares em um determinado período.

## Flags
- Depende da revisão e aprovação do PR na API do twitter: https://github.com/parlametria/leggo-twitter/pull/25