### PR TITLE
Revisa exibição do critério de avanço nas comissões

### DIFF
--- a/src/app/shared/components/destaques-proposicao/destaques-proposicao.component.html
+++ b/src/app/shared/components/destaques-proposicao/destaques-proposicao.component.html
@@ -9,13 +9,13 @@
   </ng-template>
 </span>
 <span
-  *ngIf="destaques?.criterio_avancou_comissoes"
+  *ngIf="temCriterioAvancouComissao(destaques?.comissoes_camara, destaques?.comissoes_senado, destaques?.casa_aprovacao)"
   class="tag badge badge-danger"
   [ngbPopover]="popCriterioAvancouComissao"
   [autoClose]="'outside'">
   Avançou nas comissões
   <ng-template #popCriterioAvancouComissao>
-    {{ getCriterioAvancouComissao(destaques?.comissoes_camara, destaques?.comissoes_senado) }}
+    {{ getCriterioAvancouComissao(destaques?.comissoes_camara, destaques?.comissoes_senado, destaques?.casa_aprovacao) }}
   </ng-template>
 </span>
 <span

--- a/src/app/shared/components/destaques-proposicao/destaques-proposicao.component.ts
+++ b/src/app/shared/components/destaques-proposicao/destaques-proposicao.component.ts
@@ -26,9 +26,19 @@ export class DestaquesProposicaoComponent implements OnInit {
     return str;
   }
 
-  getCriterioAvancouComissao(comissoesCamara: string, comissoesSenado: string): string {
+  temCriterioAvancouComissao(comissoesCamara: string, comissoesSenado: string, casaAprovada: string): boolean {
+    if (comissoesCamara !== null && casaAprovada !== 'camara') {
+      return true;
+    } else if (comissoesSenado !== null && casaAprovada !== 'senado') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getCriterioAvancouComissao(comissoesCamara: string, comissoesSenado: string, casaAprovada: string): string {
     let str = '';
-    if (comissoesCamara !== null) {
+    if (comissoesCamara !== null && casaAprovada !== 'camara') {
       str += 'Avançou na ' + comissoesCamara + ' da Câmara';
       if (comissoesSenado !== null) {
         str += ' e na ';
@@ -37,7 +47,7 @@ export class DestaquesProposicaoComponent implements OnInit {
         str = str.slice(0, -2);
         str += ' no Senado';
       }
-    } else if (comissoesSenado !== null) {
+    } else if (comissoesSenado !== null && casaAprovada !== 'senado') {
       str += 'Avançou na ';
       const comissoes = comissoesSenado.split(';');
       comissoes.forEach(c => str += c + ', ');


### PR DESCRIPTION
Em casos como https://leggo-painel-validacao.herokuapp.com/reforma-tributaria/proposicoes/c2553c17eeb11bd4aaa51302d18e0099/temperatura-pressao. A PLC tem a tag de casa aprovada da câmara e na tooltip de avançou nas comissões fala que ela avançou na ccjc da câmara e nas comissões do senado. Nesse caso este PR faz com que apenas as comissões do senado sejam exibidas (já que já houve a aprovação na casa da câmara). O mesmo acontece quando a casa de aprovação é o Senado. 