### PR TITLE
 (Opção 3) Adiciona aba de atuação parlamentar na página da proposição - background roxo

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -37,7 +37,9 @@
       </div>
     </div>
   </div>
-  <span>
-    Dados de atuação parlamentar a partir de 2019.
-  </span>
+  <div class="mt-4">
+    <span>
+      Dados de atuação parlamentar a partir de 2019.
+    </span>
+  </div>
 </div>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -17,18 +17,27 @@
     </div>
   </div>
   <div
-    class="mb-2"
+    class="mb-2 atuacao-body"
     *ngFor="let parlamentar of atuacao">
-    <a [routerLink]="['/', interesse, 'parlamentares', parlamentar?.values[0].id_autor_parlametria]">
-      <span *ngIf="parlamentar?.values[0].casa_autor == 'camara'">Dep.</span>
-      <span *ngIf="parlamentar?.values[0].casa_autor == 'senado'">Sen.</span>
-      {{ parlamentar?.values[0].nome_autor }}
-      {{ parlamentar?.values[0].partido }}/{{ parlamentar?.values[0].uf }}
-    </a>
-    <app-progress-stacked
-      [categorias]=parlamentar?.values
-      [min]=0
-      [max]=maximoDocumentos></app-progress-stacked>
-    {{ parlamentar?.soma_documentos }}
+    <div class="autor">
+      <a [routerLink]="['/', interesse, 'parlamentares', parlamentar?.values[0].id_autor_parlametria]">
+        <span *ngIf="parlamentar?.values[0].casa_autor == 'camara'">Dep.</span>
+        <span *ngIf="parlamentar?.values[0].casa_autor == 'senado'">Sen.</span>
+        {{ parlamentar?.values[0].nome_autor }}
+        {{ parlamentar?.values[0].partido }}/{{ parlamentar?.values[0].uf }}
+      </a>
+    </div>
+    <div class="barra">
+      <div class="barra-progresso">
+        <app-progress-stacked
+          [categorias]=parlamentar?.values
+          [min]=0
+          [max]=maximoDocumentos
+          [score]=parlamentar?.soma_documentos></app-progress-stacked>
+      </div>
+    </div>
   </div>
+  <span>
+    Dados de atuação parlamentar a partir de 2019.
+  </span>
 </div>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -14,6 +14,9 @@
       <app-legend
         [title]="'Requerimento'"
         [classe]="'bg-requerimento'"></app-legend>
+        <span class="bg-oposicao legend-title">Oposição</span>
+        <span class="bg-centro-governo legend-title">Centro/Governo</span>
+
     </div>
   </div>
   <div
@@ -21,10 +24,20 @@
     *ngFor="let parlamentar of atuacao|slice:0:numeroParlamentares let i=index">
     <div class="autor">
       <a [routerLink]="['/', interesse, 'parlamentares', parlamentar?.values[0].id_autor_parlametria]">
-        <span *ngIf="parlamentar?.values[0].casa_autor == 'camara'">Dep.</span>
-        <span *ngIf="parlamentar?.values[0].casa_autor == 'senado'">Sen.</span>
+        <span *ngIf="parlamentar?.values[0].casa_autor === 'camara'">Dep.</span>
+        <span *ngIf="parlamentar?.values[0].casa_autor === 'senado'">Sen.</span>
         {{ parlamentar?.values[0].nome_autor }}
-        {{ parlamentar?.values[0].partido }}/{{ parlamentar?.values[0].uf }}
+        <span
+          *ngIf="parlamentar?.values[0].bancada === 'oposição'"
+          class="bg-oposicao">
+          {{ parlamentar?.values[0].partido }}
+        </span>
+        <span
+          *ngIf="parlamentar?.values[0].bancada === 'governo'"
+          class="bg-centro-governo">
+          {{ parlamentar?.values[0].partido }}
+        </span>
+        /{{ parlamentar?.values[0].uf }}
       </a>
     </div>
     <div class="barra">

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -1,32 +1,34 @@
 <h3 class="titulo-sessao">Atuação parlamentar</h3>
-<app-progress-stacked
-  [categorias]="[
-    {
-      'valor': 75,
-      'classe': 'bg-primary'
-    },
-    {
-      'valor': 25,
-      'classe': 'bg-secondary'
-    }
-  ]"
-  [min]=0
-  [max]=100></app-progress-stacked>
-<br>
-  <app-progress-stacked
-  [categorias]="[
-    {
-      'valor': 10,
-      'classe': 'bg-secondary'
-    },
-    {
-      'valor': 80,
-      'classe': 'bg-primary'
-    },
-    {
-      'valor': 10,
-      'classe': 'bg-warning'
-    }
-  ]"
-  [min]=0
-  [max]=100></app-progress-stacked>
+<app-loading *ngIf="isLoading | async"></app-loading>
+<div [hidden]="isLoading | async">
+  <div class="my-4">
+    <div class="legend">
+      <app-legend
+        [title]="'Proposição'"
+        [classe]="'bg-proposicao'"></app-legend>
+
+      <app-legend
+        [title]="'Emenda'"
+        [classe]="'bg-emenda'"></app-legend>
+
+      <app-legend
+        [title]="'Requerimento'"
+        [classe]="'bg-requerimento'"></app-legend>
+    </div>
+  </div>
+  <div
+    class="mb-2"
+    *ngFor="let parlamentar of atuacao">
+    <a [routerLink]="['/', interesse, 'parlamentares', parlamentar?.values[0].id_autor_parlametria]">
+      <span *ngIf="parlamentar?.values[0].casa_autor == 'camara'">Dep.</span>
+      <span *ngIf="parlamentar?.values[0].casa_autor == 'senado'">Sen.</span>
+      {{ parlamentar?.values[0].nome_autor }}
+      {{ parlamentar?.values[0].partido }}/{{ parlamentar?.values[0].uf }}
+    </a>
+    <app-progress-stacked
+      [categorias]=parlamentar?.values
+      [min]=0
+      [max]=maximoDocumentos></app-progress-stacked>
+    {{ parlamentar?.soma_documentos }}
+  </div>
+</div>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -18,7 +18,7 @@
   </div>
   <div
     class="mb-2 atuacao-body"
-    *ngFor="let parlamentar of atuacao">
+    *ngFor="let parlamentar of atuacao|slice:0:numeroParlamentares let i=index">
     <div class="autor">
       <a [routerLink]="['/', interesse, 'parlamentares', parlamentar?.values[0].id_autor_parlametria]">
         <span *ngIf="parlamentar?.values[0].casa_autor == 'camara'">Dep.</span>
@@ -36,6 +36,14 @@
           [score]=parlamentar?.soma_documentos></app-progress-stacked>
       </div>
     </div>
+  </div>
+  <div *ngIf="atuacao?.length > NUMERO_PARLAMENTARES">
+    <button
+      class="btn btn-light btn-xs"
+      (click)="toogleShowParlamentares()">
+      <span [hidden]="numeroParlamentares === NUMERO_PARLAMENTARES">ver apenas os mais atuantes</span>
+      <span [hidden]="numeroParlamentares > NUMERO_PARLAMENTARES">ver todos os parlamentares</span>
+    </button>
   </div>
   <div class="mt-4">
     <span>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -1,1 +1,32 @@
 <h3 class="titulo-sessao">Atuação parlamentar</h3>
+<app-progress-stacked
+  [categorias]="[
+    {
+      'valor': 75,
+      'classe': 'bg-primary'
+    },
+    {
+      'valor': 25,
+      'classe': 'bg-secondary'
+    }
+  ]"
+  [min]=0
+  [max]=100></app-progress-stacked>
+<br>
+  <app-progress-stacked
+  [categorias]="[
+    {
+      'valor': 10,
+      'classe': 'bg-secondary'
+    },
+    {
+      'valor': 80,
+      'classe': 'bg-primary'
+    },
+    {
+      'valor': 10,
+      'classe': 'bg-warning'
+    }
+  ]"
+  [min]=0
+  [max]=100></app-progress-stacked>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -14,9 +14,8 @@
       <app-legend
         [title]="'Requerimento'"
         [classe]="'bg-requerimento'"></app-legend>
-        <span class="bg-oposicao legend-title">Oposição</span>
-        <span class="bg-centro-governo legend-title">Centro/Governo</span>
 
+      <span class="bg-centro-governo legend-title">Centro/Governo</span>
     </div>
   </div>
   <div
@@ -27,11 +26,7 @@
         <span *ngIf="parlamentar?.values[0].casa_autor === 'camara'">Dep.</span>
         <span *ngIf="parlamentar?.values[0].casa_autor === 'senado'">Sen.</span>
         {{ parlamentar?.values[0].nome_autor }}
-        <span
-          *ngIf="parlamentar?.values[0].bancada === 'oposição'"
-          class="bg-oposicao">
-          {{ parlamentar?.values[0].partido }}
-        </span>
+        <span *ngIf="parlamentar?.values[0].bancada === 'oposição'">{{ parlamentar?.values[0].partido }}</span>
         <span
           *ngIf="parlamentar?.values[0].bancada === 'governo'"
           class="bg-centro-governo">

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.html
@@ -1,0 +1,1 @@
+<h3 class="titulo-sessao">Atuação parlamentar</h3>

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
@@ -4,34 +4,34 @@
 }
 
 .atuacao-body {
-  display: flex;
-  justify-content: space-between;
+  @media (min-width: 992px) {
+    display: flex;
+    justify-content: space-between;
+  }
 }
 
 .barra {
   display: flex;
-  // justify-content: space-between;
-  // align-items: center;
-  width: 70%;
-  height: 27px;
+  width: 75%;
+  height: 32px;
 
-  // @media (min-width: 992px) {
-  //   width: 70%;
-  // }
+  @media (max-width: 992px) {
+    width: 100%;
+  }
 }
 
 .autor {
   display: flex;
-  max-width: 30%;
+  width: 25%;
   font-size: 0.9rem;
+
+  @media (max-width: 992px) {
+    width: 100%;
+  }
 }
 
 .barra-progresso {
   width: 100%;
-
-  // @media (min-width: 992px) {
-  //   width: 100%;
-  // }
 }
 
 .barra-score {

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
@@ -1,0 +1,4 @@
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
@@ -3,6 +3,10 @@
   flex-wrap: wrap;
 }
 
+.legend-title {
+  margin-right: 1rem;
+}
+
 .atuacao-body {
   @media (min-width: 992px) {
     display: flex;

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
@@ -2,3 +2,39 @@
   display: flex;
   flex-wrap: wrap;
 }
+
+.atuacao-body {
+  display: flex;
+  justify-content: space-between;
+}
+
+.barra {
+  display: flex;
+  // justify-content: space-between;
+  // align-items: center;
+  width: 70%;
+  height: 27px;
+
+  // @media (min-width: 992px) {
+  //   width: 70%;
+  // }
+}
+
+.autor {
+  display: flex;
+  max-width: 30%;
+  font-size: 0.9rem;
+}
+
+.barra-progresso {
+  width: 100%;
+
+  // @media (min-width: 992px) {
+  //   width: 100%;
+  // }
+}
+
+.barra-score {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+}

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.scss
@@ -21,12 +21,14 @@
 }
 
 .autor {
-  display: flex;
   width: 25%;
   font-size: 0.9rem;
+  margin-right: 5px;
+  text-align: right;
 
   @media (max-width: 992px) {
     width: 100%;
+    text-align: left;
   }
 }
 

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.spec.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AtuacaoParlamentarComponent } from './atuacao-parlamentar.component';
+
+describe('AtuacaoParlamentarComponent', () => {
+  let component: AtuacaoParlamentarComponent;
+  let fixture: ComponentFixture<AtuacaoParlamentarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AtuacaoParlamentarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AtuacaoParlamentarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { Subject, forkJoin } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { AutoriasService } from 'src/app/shared/services/autorias.service';
+import { AtorService } from 'src/app/shared/services/ator.service';
+
+@Component({
+  selector: 'app-atuacao-parlamentar',
+  templateUrl: './atuacao-parlamentar.component.html',
+  styleUrls: ['./atuacao-parlamentar.component.scss']
+})
+export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
+
+  private unsubscribe = new Subject();
+
+  idLeggo: string;
+
+  atuacao: any[];
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private autoriaService: AutoriasService,
+    private atorService: AtorService) { }
+
+  ngOnInit(): void {
+    this.activatedRoute.parent.paramMap
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe((params) => {
+        this.idLeggo = params.get('id_leggo');
+        if (this.idLeggo !== undefined) {
+          this.getAtuacaoParlamentar(this.idLeggo);
+        }
+      });
+  }
+
+  getAtuacaoParlamentar(idLeggo: string) {
+    forkJoin([
+      this.autoriaService.getAutoriasPorProposicao(idLeggo),
+      this.atorService.getAtoresBancadas()
+    ])
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(data => {
+        const autorias = data[0]
+        const bancadas = data[1]
+
+        const atuacao = autorias.map(a => ({
+          bancada: this.getProperty(bancadas.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
+            'bancada'),
+          ...a
+        }));
+        console.log(atuacao);
+        this.atuacao = atuacao;
+      });
+  }
+
+  private getProperty(objeto: any, property: string) {
+    if (objeto === undefined) {
+      return undefined;
+    } else {
+      return objeto[property];
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe.next();
+    this.unsubscribe.complete();
+  }
+
+}

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -122,7 +122,7 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
 
   private getTooltip(atuacao) {
     const tipo = atuacao.tipo_documento === 'Prop. Original / Apensada' ? 'Proposição' : atuacao.tipo_documento;
-    const acoes = atuacao.total_documentos === 1 ? ' ação': ' ações';
+    const acoes = atuacao.total_documentos === 1 ? ' ação' : ' ações';
 
     return tipo + ': ' + atuacao.total_documentos + acoes;
   }

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -121,11 +121,10 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
   }
 
   private getTooltip(atuacao) {
-    let tipo = atuacao.tipo_documento;
-    if (tipo === 'Prop. Original / Apensada') {
-      tipo = 'Proposição';
-    }
-    return tipo + ': ' + atuacao.total_documentos + ' ações';
+    const tipo = atuacao.tipo_documento === 'Prop. Original / Apensada' ? 'Proposição' : atuacao.tipo_documento;
+    const acoes = atuacao.total_documentos === 1 ? ' ação': ' ações';
+
+    return tipo + ': ' + atuacao.total_documentos + acoes;
   }
 
   private getProperty(objeto: any, property: string) {

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subject, forkJoin, BehaviorSubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { nest } from 'd3-collection';
-import { max } from "d3-array";
+import { max } from 'd3-array';
 const d3 = Object.assign({}, { nest, max });
 
 import { AutoriasService } from 'src/app/shared/services/autorias.service';
@@ -72,13 +72,13 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
           .key((d: any) => d.id_autor_parlametria)
           .entries(atuacao);
 
-        this.atuacao.map(a => {
-          a.values.map(atuacao => {
-            atuacao.valor = atuacao.total_documentos;
-            atuacao.classe = this.getClasseTipoDocumento(atuacao.tipo_documento);
-            atuacao.tooltip = this.getTooltip(atuacao);
-          })
-          a.values.sort((a, b) => {
+        this.atuacao.map(parlamentar => {
+          parlamentar.values.map(autoria => {
+            autoria.valor = autoria.total_documentos;
+            autoria.classe = this.getClasseTipoDocumento(autoria.tipo_documento);
+            autoria.tooltip = this.getTooltip(autoria);
+          });
+          parlamentar.values.sort((a, b) => {
             const orderA = this.ORDER_TIPOS_PROPOSICAO.indexOf(a.tipo_documento);
             const orderB = this.ORDER_TIPOS_PROPOSICAO.indexOf(b.tipo_documento);
             if (orderA === -1) {
@@ -88,13 +88,13 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
               return -1;
             }
             return orderA - orderB;
-          })
-          a.soma_documentos = a.values.reduce((accum, item) => accum + item.total_documentos, 0)
-          return a
-        })
+          });
+          parlamentar.soma_documentos = parlamentar.values.reduce((accum, item) => accum + item.total_documentos, 0);
+          return parlamentar;
+        });
         this.atuacao.sort((a, b) => b.soma_documentos - a.soma_documentos);
 
-        this.maximoDocumentos = d3.max(this.atuacao, d => { return +d.soma_documentos; });
+        this.maximoDocumentos = d3.max(this.atuacao, d => +d.soma_documentos );
 
         this.isLoading.next(false);
         console.log(this.atuacao);
@@ -102,7 +102,7 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
   }
 
   private getClasseTipoDocumento(tipoDocumento: string) {
-    let classe = ""
+    let classe = '';
     switch (tipoDocumento) {
       case 'Prop. Original / Apensada':
         classe = 'bg-proposicao';

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -43,8 +43,8 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
     ])
       .pipe(takeUntil(this.unsubscribe))
       .subscribe(data => {
-        const autorias = data[0]
-        const bancadas = data[1]
+        const autorias = data[0];
+        const bancadas = data[1];
 
         const atuacao = autorias.map(a => ({
           bancada: this.getProperty(bancadas.find(p => a.id_autor_parlametria === p.id_autor_parlametria),

--- a/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/atuacao-parlamentar/atuacao-parlamentar.component.ts
@@ -26,10 +26,12 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
     'Emenda',
     'Requerimento'
   ];
+  readonly NUMERO_PARLAMENTARES = 15;
 
   idLeggo: string;
   interesse: string;
   maximoDocumentos: number;
+  numeroParlamentares = this.NUMERO_PARLAMENTARES;
 
   atuacao: any[];
 
@@ -97,8 +99,15 @@ export class AtuacaoParlamentarComponent implements OnInit, OnDestroy {
         this.maximoDocumentos = d3.max(this.atuacao, d => +d.soma_documentos );
 
         this.isLoading.next(false);
-        console.log(this.atuacao);
       });
+  }
+
+  toogleShowParlamentares() {
+    if (this.numeroParlamentares < this.atuacao.length) {
+      this.numeroParlamentares = this.atuacao.length;
+    } else {
+      this.numeroParlamentares = this.NUMERO_PARLAMENTARES;
+    }
   }
 
   private getClasseTipoDocumento(tipoDocumento: string) {

--- a/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao-routing.module.ts
+++ b/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao-routing.module.ts
@@ -4,6 +4,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { DetalhesProposicaoComponent } from './detalhes-proposicao.component';
 import { ProgressoComponent } from './progresso/progresso.component';
 import { TemperaturaPressaoComponent } from './temperatura-pressao/temperatura-pressao.component';
+import { AtuacaoParlamentarComponent } from './atuacao-parlamentar/atuacao-parlamentar.component';
 
 const appRoutes: Routes = [
   {
@@ -22,6 +23,10 @@ const appRoutes: Routes = [
       {
         path: 'progresso',
         component: ProgressoComponent
+      },
+      {
+        path: 'atuacao',
+        component: AtuacaoParlamentarComponent
       },
     ]
   }

--- a/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
@@ -88,6 +88,16 @@
         Progresso
       </a>
     </li>
+    <li class="nav-item">
+      <a
+        class="nav-link"
+        [routerLink]="['./atuacao']"
+        [routerLinkActive]="'active'"
+        queryParamsHandling="merge">
+        <span class="icon-atividade"></span>
+        Atuação parlamentar
+      </a>
+    </li>
   </ul>
 </div>
 <div class="container">

--- a/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.module.ts
+++ b/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.module.ts
@@ -13,6 +13,7 @@ import { DetalhesProposicaoRoutingModule } from './detalhes-proposicao-routing.m
 import { ListaAutoresComponent } from './lista-autores/lista-autores.component';
 import { ListaRelatoresComponent } from './lista-relatores/lista-relatores.component';
 import { ProgressoComponent } from './progresso/progresso.component';
+import { AtuacaoParlamentarComponent } from './atuacao-parlamentar/atuacao-parlamentar.component';
 
 @NgModule({
   declarations: [
@@ -21,7 +22,8 @@ import { ProgressoComponent } from './progresso/progresso.component';
     ListaRelatoresComponent,
     TemperaturaPressaoComponent,
     VisTemperaturaPressaoComponent,
-    ProgressoComponent
+    ProgressoComponent,
+    AtuacaoParlamentarComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/shared/components/legend/legend.component.html
+++ b/src/app/shared/components/legend/legend.component.html
@@ -1,0 +1,4 @@
+<div class="d-flex">
+  <div [ngClass]="getClass()"></div>
+  <div class="legend-title">{{ title }}</div>
+</div>

--- a/src/app/shared/components/legend/legend.component.scss
+++ b/src/app/shared/components/legend/legend.component.scss
@@ -1,0 +1,19 @@
+.legend-info {
+  width: 15px;
+  height: 15px;
+  margin-top: 5px;
+  margin-right: 0.5rem;
+  border: solid 1px #20201e;
+}
+
+.legend-title {
+  font-size: 0.8rem;
+  line-height: 23px;
+  margin-right: 1rem;
+  word-wrap: break-word;
+}
+
+.legend-rounded {
+  border-radius: 50%;
+  border: solid 1px #adb5bd;
+}

--- a/src/app/shared/components/legend/legend.component.spec.ts
+++ b/src/app/shared/components/legend/legend.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LegendComponent } from './legend.component';
+
+describe('LegendComponent', () => {
+  let component: LegendComponent;
+  let fixture: ComponentFixture<LegendComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LegendComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LegendComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/legend/legend.component.ts
+++ b/src/app/shared/components/legend/legend.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-legend',
+  templateUrl: './legend.component.html',
+  styleUrls: ['./legend.component.scss']
+})
+export class LegendComponent implements OnInit {
+  @Input() title: string;
+  @Input() classe: string;
+  @Input() rounded: boolean;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  getClass(): string[] {
+    const classes = ['legend-info', this.classe];
+    if (this.rounded) {
+      classes.push('legend-rounded');
+    }
+
+    return classes;
+  }
+
+}

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.html
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.html
@@ -8,6 +8,5 @@
     [attr.aria-valuemin]="min"
     [attr.aria-valuemax]="max"
     [hidden]="!categoria.valor"
-  >
-  </div>
+    [ngbPopover]="categoria.tooltip"></div>
 </div>

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.html
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.html
@@ -1,0 +1,13 @@
+<div class="progress progress-stacked">
+  <div
+    *ngFor="let categoria of categorias"
+    role="progressbar"
+    [ngStyle]="{'width': (categoria.valor / max)*100+'%'}"
+    class="progress-bar progress-stacked-bar progress-bordered {{ categoria.classe }}"
+    [attr.aria-valuenow]="categoria.valor"
+    [attr.aria-valuemin]="min"
+    [attr.aria-valuemax]="max"
+    [hidden]="!categoria.valor"
+  >
+  </div>
+</div>

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.html
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.html
@@ -9,4 +9,7 @@
     [attr.aria-valuemax]="max"
     [hidden]="!categoria.valor"
     [ngbPopover]="categoria.tooltip"></div>
+    <div *ngIf="score" class="progress-bar-value">
+      {{ score }}
+    </div>
 </div>

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.scss
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.scss
@@ -1,0 +1,12 @@
+.progress-stacked-bar {
+  padding-right: 0.25rem;
+  text-align: right;
+  color: #20201e;
+}
+
+.progress-bordered {
+  border-left: solid 1px;
+  border-right: solid 1px;
+  border-bottom: solid 1px;
+  border-top: none;
+}

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.scss
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.scss
@@ -2,6 +2,7 @@
   padding-right: 0.25rem;
   text-align: right;
   color: #20201e;
+  cursor: pointer;
 }
 
 .progress-bordered {

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.scss
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.scss
@@ -11,3 +11,8 @@
   border-bottom: solid 1px;
   border-top: none;
 }
+
+.progress-bar-value {
+  line-height: normal;
+  margin-left: 5px;
+}

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.spec.ts
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressStackedComponent } from './progress-stacked.component';
+
+describe('ProgressStackedComponent', () => {
+  let component: ProgressStackedComponent;
+  let fixture: ComponentFixture<ProgressStackedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProgressStackedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProgressStackedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.ts
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.ts
@@ -10,6 +10,7 @@ export class ProgressStackedComponent {
   @Input() categorias: any[];
   @Input() min: number;
   @Input() max: number;
+  @Input() score: number;
 
   constructor() { }
 

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.ts
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-progress-stacked',
+  templateUrl: './progress-stacked.component.html',
+  styleUrls: ['./progress-stacked.component.scss']
+})
+export class ProgressStackedComponent {
+
+  @Input() categorias: any[];
+  @Input() min: number;
+  @Input() max: number;
+
+  constructor() { }
+
+}

--- a/src/app/shared/components/progress-stacked/progress-stacked.component.ts
+++ b/src/app/shared/components/progress-stacked/progress-stacked.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-progress-stacked',

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -14,6 +14,7 @@ import { TooltipAjudaComponent } from './tooltip-ajuda/tooltip-ajuda.component';
 import { EmbedTweetComponent } from './embed-tweet/embed-tweet.component';
 import { DestaquesProposicaoComponent } from './destaques-proposicao/destaques-proposicao.component';
 import { ProgressStackedComponent } from './progress-stacked/progress-stacked.component';
+import { LegendComponent } from './legend/legend.component';
 
 @NgModule({
   declarations: [
@@ -25,7 +26,8 @@ import { ProgressStackedComponent } from './progress-stacked/progress-stacked.co
     TooltipAjudaComponent,
     DestaquesProposicaoComponent,
     EmbedTweetComponent,
-    ProgressStackedComponent
+    ProgressStackedComponent,
+    LegendComponent
   ],
   imports: [
     CommonModule,
@@ -42,7 +44,8 @@ import { ProgressStackedComponent } from './progress-stacked/progress-stacked.co
     TooltipAjudaComponent,
     DestaquesProposicaoComponent,
     EmbedTweetComponent,
-    ProgressStackedComponent
+    ProgressStackedComponent,
+    LegendComponent
   ]
 })
 export class SharedComponentsModule { }

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -13,6 +13,7 @@ import { FiltraTemaComponent } from './filtra-tema/filtra-tema.component';
 import { TooltipAjudaComponent } from './tooltip-ajuda/tooltip-ajuda.component';
 import { EmbedTweetComponent } from './embed-tweet/embed-tweet.component';
 import { DestaquesProposicaoComponent } from './destaques-proposicao/destaques-proposicao.component';
+import { ProgressStackedComponent } from './progress-stacked/progress-stacked.component';
 
 @NgModule({
   declarations: [
@@ -23,7 +24,8 @@ import { DestaquesProposicaoComponent } from './destaques-proposicao/destaques-p
     FiltraTemaComponent,
     TooltipAjudaComponent,
     DestaquesProposicaoComponent,
-    EmbedTweetComponent
+    EmbedTweetComponent,
+    ProgressStackedComponent
   ],
   imports: [
     CommonModule,
@@ -39,7 +41,8 @@ import { DestaquesProposicaoComponent } from './destaques-proposicao/destaques-p
     FiltraTemaComponent,
     TooltipAjudaComponent,
     DestaquesProposicaoComponent,
-    EmbedTweetComponent
+    EmbedTweetComponent,
+    ProgressStackedComponent
   ]
 })
 export class SharedComponentsModule { }

--- a/src/app/shared/models/atorBancada.model.ts
+++ b/src/app/shared/models/atorBancada.model.ts
@@ -1,0 +1,4 @@
+export interface AtorBancada {
+  id_autor_parlametria: number;
+  bancada: string;
+}

--- a/src/app/shared/models/autoriaProposicao.ts
+++ b/src/app/shared/models/autoriaProposicao.ts
@@ -1,6 +1,9 @@
 export interface AutoriaProposicao {
   id_autor_parlametria: number;
   casa_autor: string;
+  nome_autor: string;
+  partido: string;
+  uf: string;
   tipo_documento: string;
   peso_documentos: number;
   total_documentos: number;

--- a/src/app/shared/models/autoriaProposicao.ts
+++ b/src/app/shared/models/autoriaProposicao.ts
@@ -1,0 +1,7 @@
+export interface AutoriaProposicao {
+  id_autor_parlametria: number;
+  casa_autor: string;
+  tipo_documento: string;
+  peso_documentos: number;
+  total_documentos: number;
+}

--- a/src/app/shared/services/ator.service.ts
+++ b/src/app/shared/services/ator.service.ts
@@ -5,10 +5,9 @@ import { Observable } from 'rxjs';
 
 import { Ator } from '../models/ator.model';
 import { AtorAgregado } from '../models/atorAgregado.model';
-import { Autoria } from '../models/autoria.model';
 
 import { environment } from '../../../environments/environment';
-import { ProposicoesService } from './proposicoes.service';
+import { AtorBancada } from '../models/atorBancada.model';
 
 @Injectable({
   providedIn: 'root'
@@ -34,6 +33,10 @@ export class AtorService {
       .set('interesse', interesse)
       .set('tema', tema);
     return this.http.get<any[]>(`${this.atoresUrl}/agregados/${idAutor}`, { params });
+  }
+
+  getAtoresBancadas(): Observable<AtorBancada[]> {
+    return this.http.get<AtorBancada[]>(`${this.atoresUrl}/bancadas`);
   }
 
 }

--- a/src/app/shared/services/autorias.service.ts
+++ b/src/app/shared/services/autorias.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AutoriaAgregada } from '../models/autoriaAgregada.model';
 import { Autoria } from '../models/autoria.model';
+import { AutoriaProposicao } from '../models/autoriaProposicao';
 
 @Injectable({
   providedIn: 'root'
@@ -40,4 +41,9 @@ export class AutoriasService {
   getAutoriasAgregadasProjetos(interesse: string, tema: string): Observable<Autoria[]> {
     return this.http.get<Autoria[]>(`${this.autoriaUrl}/projetos/?interesse=${interesse}&tema=${tema}`);
   }
+
+  getAutoriasPorProposicao(idLeggo: string): Observable<AutoriaProposicao[]> {
+    return this.http.get<AutoriaProposicao[]>(`${this.autoriaUrl}/${idLeggo}/parlamentares`);
+  }
+
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -376,7 +376,7 @@
 }
 /* Gráficos FIM */
 
-/* Backgrounds Tipos de documento */
+/* Backgrounds */
 
 .bg-proposicao {
   background-color: #32626F;
@@ -394,4 +394,12 @@
   background-color: $info;
 }
 
-/* Backgrounds Tipos de documento FIM */
+.bg-oposicao {
+  background-color: #fdc9b4;
+}
+
+.bg-centro-governo {
+  background-color: #cfe1f2;
+}
+
+/* Backgrounds FIM */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -399,7 +399,7 @@
 }
 
 .bg-centro-governo {
-  background-color: #cfe1f2;
+  background-color: #B29AD6;
 }
 
 /* Backgrounds FIM */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -375,3 +375,23 @@
   pointer-events: all;
 }
 /* Gráficos FIM */
+
+/* Backgrounds Tipos de documento */
+
+.bg-proposicao {
+  background-color: #32626F;
+}
+
+.bg-emenda {
+  background-color: #57B494;
+}
+
+.bg-requerimento {
+  background-color: #B1EAA3;
+}
+
+.bg-neutro {
+  background-color: $info;
+}
+
+/* Backgrounds Tipos de documento FIM */


### PR DESCRIPTION
## Mudanças
- Adiciona aba de atuação parlamentar na página da proposição
- Adiciona serviços para consultar atuação parlamentar por proposição
- Marca a bancada pela cor do background do Centro/Governo para Roxo
- Deve ser aceito este PR ou o alternativo https://github.com/parlametria/leggo-painel/pull/210 ou https://github.com/parlametria/leggo-painel/pull/209

## Flags
- Depende da revisão do PR do backend https://github.com/parlametria/leggo-backend/pull/312