### PR TITLE
Exibe advocacy box no card da proposição e na página detalhada

### DIFF
--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -45,7 +45,29 @@
       </a>
     </div>
     <div class="tags mt-3">
-      <app-destaques-proposicao [destaques]="destaques" *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
+      <div>
+        <app-destaques-proposicao
+          [destaques]="destaques"
+          *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
+        <span
+          class="tag badge badge-gray"
+          *ngIf="proposicao?.interesse[0]?.advocacy_link && proposicao?.interesse[0]?.advocacy_link !== 'nan'"
+          [ngbPopover]="popAdvocacy"
+          [autoClose]="'outside'">
+          advocacy box
+        </span>
+        <ng-template #popAdvocacy>
+          Existem notas técnicas de OSCs disponíveis para esta proposição.
+          <div class="text-right">
+            <a
+              href="{{proposicao?.interesse[0]?.advocacy_link}}"
+              target="_blank"
+              class="btn btn-link btn-sm">
+              Ver notas
+            </a>
+          </div>
+        </ng-template>
+      </div>
       <div *ngIf="!proposicao?.destaques.length">
         <span
           *ngIf="!['Ordinária', 'Indefinido'].includes(proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao)"
@@ -83,24 +105,6 @@
           [autoClose]="'outside'">
             Insight em {{ proposicao?.anotacao_data_ultima_modificacao | date:'dd/MM/yyyy' }}
         </span> -->
-        <span
-          class="tag badge badge-gray"
-          *ngIf="proposicao?.interesse[0]?.advocacy_link && proposicao?.interesse[0]?.advocacy_link !== 'nan'"
-          [ngbPopover]="popAdvocacy"
-          [autoClose]="'outside'">
-          advocacy box
-        </span>
-        <ng-template #popAdvocacy>
-          Existem notas técnicas de OSCs disponíveis para esta proposição.
-          <div class="text-right">
-            <a
-              href="{{proposicao?.interesse[0]?.advocacy_link}}"
-              target="_blank"
-              class="btn btn-link btn-sm">
-              Ver notas
-            </a>
-          </div>
-        </ng-template>
       </div>
       <div class="d-flex">
         <div

--- a/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
@@ -28,7 +28,9 @@
         {{ temas }}
       </li>
     </ol>
-    <h2>{{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}</h2>
+    <h2>
+      {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}
+    </h2>
 
     <div class="mb-4">
       <ol class="breadcrumb proposicao-temas">
@@ -52,7 +54,27 @@
         [autoClose]="'outside'">
         {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.status }}
       </span>
-      <app-destaques-proposicao [destaques]="destaques" *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
+      <app-destaques-proposicao
+        [destaques]="destaques"
+        *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
+      <span
+        class="tag badge badge-gray"
+        *ngIf="proposicao?.interesse[0]?.advocacy_link && proposicao?.interesse[0]?.advocacy_link !== 'nan'"
+        [ngbPopover]="popAdvocacy"
+        [autoClose]="'outside'">
+        advocacy box
+      </span>
+      <ng-template #popAdvocacy>
+        Existem notas técnicas de OSCs disponíveis para esta proposição.
+        <div class="text-right">
+          <a
+            href="{{proposicao?.interesse[0]?.advocacy_link}}"
+            target="_blank"
+            class="btn btn-link btn-sm">
+            Ver notas
+          </a>
+        </div>
+      </ng-template>
     </div>
     <app-lista-autores [autores]="proposicao?.autoresProposicao"></app-lista-autores>
     <app-lista-relatores [etapas]="proposicao?.etapas"></app-lista-relatores>


### PR DESCRIPTION
## Mudanças
- Conserta exibição da tag do advocacy box no card da proposição
- Exibe advocacy box na página detalhada da proposição

## Flags
- Proposições com advocacy box: [PL 3723/2019](http://localhost:4200/leggo/proposicoes/7c4cbac341769f758f433b3f2e0c08c9/temperatura-pressao) e [PL 3261/2019](http://localhost:4200/leggo/proposicoes/d8a02979d2829415b1b87a300ce96d86/temperatura-pressao)
- closes #221 
