### PR TITLE
Não exibe tema nan na página de detalhes da proposição

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/detalhes-proposicao.component.html
@@ -24,8 +24,8 @@
     <ol class="breadcrumb proposicao-temas">
       <li
         class="breadcrumb-item text-muted"
-        *ngFor="let temas of proposicao?.interesse[0]?.temas">
-        {{ temas }}
+        *ngFor="let tema of proposicao?.interesse[0]?.temas">
+        <span *ngIf="tema !== 'nan'">{{ tema }}</span>
       </li>
     </ol>
     <h2>


### PR DESCRIPTION
## Mudanças
- Não exibe tema nan na página de detalhes da proposição

## flags 
- Depende da revisão do PR do backend https://github.com/parlametria/leggo-backend/pull/322