### PR TITLE
Adiciona descrição dos painéis e outros textos estáticos

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,6 +1,10 @@
 <app-loading *ngIf="isLoading | async"></app-loading>
 
-<div class="main-subnav mt-4 pt-4">
+<div class="container descricao-interesse">
+  {{ interesse.descricao_interesse }}
+</div>
+
+<div class="main-subnav">
   <ul class="nav nav-tabs justify-content-center">
     <li class="nav-item">
       <a

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -38,3 +38,8 @@ $base-padding: 0.5rem;
     }
   }
 }
+
+.descricao-interesse {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}

--- a/src/app/home/selecao-painel/selecao-painel.component.html
+++ b/src/app/home/selecao-painel/selecao-painel.component.html
@@ -1,6 +1,11 @@
 <div class="paineis">
   <div class="container app-container">
-    <h2 class="text-center mb-4">Selecione o painel</h2>
+    <p>
+      Nos painéis, utilizamos o aprendizado de máquina e a ciência de dados para coletar informações da Câmara dos Deputados e do Senado Federal. Com isso, identificamos a ação legislativa das proposições, para aferir a temperatura, o modo como o conteúdo é alterado e os atores nesse processo.
+
+      Hoje, possuímos <strong>{{ interesses.length }} painéis ativos</strong>.
+    </p>
+    <h2 class="text-center my-4">Selecione o painel desejado</h2>
     <div class="d-flex justify-content-center">
       <div class="row gutters-sm py-4">
         <div

--- a/src/app/home/selecao-painel/selecao-painel.component.scss
+++ b/src/app/home/selecao-painel/selecao-painel.component.scss
@@ -9,6 +9,13 @@
 .paineis-selecao {
   padding: 1rem;
   margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media (min-width: 576px) {
+    height: 100px;
+  }
 
   @media (min-width: 992px) {
     padding: 3rem;

--- a/src/app/home/sobre/sobre.component.html
+++ b/src/app/home/sobre/sobre.component.html
@@ -5,7 +5,7 @@
   <section class="section">
     <div class="row">
       <div class="col-lg-6 pb-4">
-        <h4 class="footer-title">Leggo</h4>
+        <h4 class="footer-title">Painéis de acompanhamento</h4>
         <p>
           A plataforma coleta e analisa dados do Congresso Nacional, para apresentar uma
           <strong class="strong">visão geral e agregada</strong> das proposições mais relevantes sobre o tema, permitindo o acompanhamento,
@@ -50,7 +50,7 @@
       </div>
       <div class="col-md-6">
         <p class="featured-box">
-          O Leggo, portanto, procura atender a essa demanda: utilizar a inteligência de dados para a ação cidadã, nos temas e assuntos que interessam à sociedade acompanhar e influenciar a atuação do Legislativo.
+          Parlametria, portanto, procura atender a essa demanda: utilizar a inteligência de dados para a ação cidadã, nos temas e assuntos que interessam à sociedade acompanhar e influenciar a atuação do Legislativo.
         </p>
       </div>
     </div>


### PR DESCRIPTION
- É possível ver o texto descritivo do painel selecionado na página inicial
- Texto estático sobre o parlametria na seleção de painéis
- Atualização do Sobre (removendo o nome 'leggo')