### PR TITLE
Cria serviço para recuperar dados de governismo

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,7 +1,7 @@
 <app-loading *ngIf="isLoading | async"></app-loading>
 
 <div class="container descricao-interesse">
-  {{ interesse.descricao_interesse }}
+  {{ interesse?.descricao_interesse }}
 </div>
 
 <div class="main-subnav">

--- a/src/app/shared/models/atorAgregado.model.ts
+++ b/src/app/shared/models/atorAgregado.model.ts
@@ -17,4 +17,5 @@ export interface AtorAgregado {
   indice: number;
   casa_autor: string;
   quantidade_tweets: number;
+  governismo: number;
 }

--- a/src/app/shared/models/governismo.model.ts
+++ b/src/app/shared/models/governismo.model.ts
@@ -1,0 +1,5 @@
+export interface Governismo {
+  id_parlamentar_parlametria: number;
+  casa: string;
+  governismo: number;
+}

--- a/src/app/shared/services/governismo.service.spec.ts
+++ b/src/app/shared/services/governismo.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GovernismoService } from './governismo.service';
+
+describe('GovernismoService', () => {
+  let service: GovernismoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GovernismoService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/governismo.service.ts
+++ b/src/app/shared/services/governismo.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+import { Governismo } from '../models/governismo.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GovernismoService {
+
+  private governismoUrl = `${environment.baseUrl}/governismo`;
+
+  constructor(private http: HttpClient) { }
+
+  getGovernismo(): Observable<Governismo> {
+    return this.http.get<Governismo>(`${this.governismoUrl}/`);
+  }
+
+  getGovernismoByID(idParlamentar: string): Observable<Governismo> {
+    return this.http.get<Governismo>(`${this.governismoUrl}/${idParlamentar}`);
+  }
+}

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -11,6 +11,7 @@ import { PesoPoliticoService } from 'src/app/shared/services/peso-politico.servi
 import { RelatoriaService } from 'src/app/shared/services/relatoria.service';
 import { EntidadeService } from 'src/app/shared/services/entidade.service';
 import { TwitterService } from 'src/app/shared/services/twitter.service';
+import { GovernismoService } from './governismo.service';
 
 @Injectable({
   providedIn: 'root'
@@ -31,7 +32,8 @@ export class ParlamentaresService {
     private pesoService: PesoPoliticoService,
     private relatoriaService: RelatoriaService,
     private entidadeService: EntidadeService,
-    private twitterService: TwitterService
+    private twitterService: TwitterService,
+    private governismoService: GovernismoService
   ) {
 
     this.parlamentares
@@ -85,7 +87,8 @@ export class ParlamentaresService {
         this.relatoriaService.getAtoresRelatores(interesse, tema, destaque),
         this.pesoService.getPesoPolitico(),
         this.twitterService.getAtividadeTwitter(interesse, tema, dataInicial, dataFinal, destaque),
-        this.autoriaService.getAutoriasAgregadasProjetos(interesse, tema, destaque)
+        this.autoriaService.getAutoriasAgregadasProjetos(interesse, tema, destaque),
+        this.governismoService.getGovernismo()
       ]
     )
       .subscribe(data => {
@@ -96,6 +99,7 @@ export class ParlamentaresService {
         const pesoPolitico: any = data[4];
         const twitter: any = data[5];
         const autoriasProjetos: any = data[6];
+        const governismo: any = data[7];
 
         const parlamentares = parlamentaresExercicio.map(a => ({
           ...autoriasAgregadas.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
@@ -104,6 +108,7 @@ export class ParlamentaresService {
           ...pesoPolitico.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
           ...twitter.find(p => a.id_autor_parlametria === +p.id_parlamentar_parlametria),
           ...autoriasProjetos.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
+          ...governismo.find(p => a.id_autor_parlametria === p.id_parlamentar_parlametria),
           ...a
         }));
 


### PR DESCRIPTION
## Mudanças
- Cria serviço para recuperar governismo
- Adiciona dado de governismo no observable da lista de parlamentares
- Corrige erro no console para interesses

## Flags
- É preciso estar na branch [sprint-42](https://github.com/parlametria/leggo-backend/tree/sprint-42) do backend e com os dados de governismo importados no banco.