### PR TITLE
Ajusta escala do gráfico de pressão

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -193,10 +193,10 @@ export class VisTemperaturaPressaoComponent implements OnInit {
     this.x.domain(d3.extent(dados, (d: any) => d.data));
     this.yTemperatura.domain([0, temperaturaMax]);
     const maxPressao = +d3.max(dados, (d: any) => d.valorPressao);
-    if (maxPressao > 0) {
+    if (maxPressao > 100) {
       this.yPressao.domain([0, maxPressao]);
     } else {
-      this.yPressao.domain([0, 1]);
+      this.yPressao.domain([0, 100]);
     }
 
     const lineTemperatura = d3.line()


### PR DESCRIPTION
Se a pressão máxima passa de 100, ela será o máximo da escala, senão, a escala é fixa entre 0-100.