### PR TITLE
Separa ações legislativas em 2 grupos

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
@@ -23,15 +23,22 @@
     </div>
   </div>
 </div>
-<div
-  *ngIf="filtro?.data">
+<div *ngIf="filtro?.data">
   <h3 class="titulo-sessao">
     Ações legislativas de {{ getSemanaString(filtro?.data) }}
   </h3>
-  <div *ngIf="!eventos.length">Nenhuma ação legislativa nesta semana.</div>
-  <ul>
+  <div *ngIf="!eventosPrincipais.length || !eventosSecundarios.length">Nenhuma ação legislativa nesta semana.</div>
+  <ul *ngIf="eventosPrincipais.length">
     <app-evento-tramitacao
       [evento]="evento"
-      *ngFor="let evento of eventos"></app-evento-tramitacao>
+      *ngFor="let evento of eventosPrincipais"></app-evento-tramitacao>
   </ul>
+  <div *ngIf="eventosSecundarios.length">
+    <p><button class="btn btn-light" (click)="toggleShowMais()">Ver mais ações nesta semana</button></p>
+    <ul *ngIf="showMais">
+      <app-evento-tramitacao
+        [evento]="evento"
+        *ngFor="let evento of eventosSecundarios"></app-evento-tramitacao>
+    </ul>
+  </div>
 </div>

--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
@@ -18,8 +18,10 @@ export class TemperaturaPressaoComponent implements OnInit {
   public idLeggo: string;
   public isLoading = new BehaviorSubject<boolean>(true);
 
-  public eventos;
+  public eventosPrincipais;
+  public eventosSecundarios;
   public filtro;
+  public showMais = false;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -41,11 +43,13 @@ export class TemperaturaPressaoComponent implements OnInit {
     this.eventosService.getEventosTramitacao(idLeggo, 'reforma-tributaria')
       .pipe(indicate(this.isLoading))
       .subscribe(eventos => {
-        this.eventos = eventos;
+        this.eventosPrincipais = eventos.filter(e => (typeof e.evento !== 'undefined' && e.evento !== 'nan'));
+        this.eventosSecundarios = eventos.filter(e => (typeof e.evento === 'undefined' || e.evento === 'nan'));
       });
   }
 
   dataOnChange(event) {
+    this.showMais = false;
     this.filtro = event;
     this.eventosService.pesquisar(event);
   }
@@ -64,6 +68,10 @@ export class TemperaturaPressaoComponent implements OnInit {
       return evento.texto_tramitacao.split('.')[0] + '...';
     }
     return '';
+  }
+
+  toggleShowMais() {
+    this.showMais = !this.showMais;
   }
 
 }


### PR DESCRIPTION
Ao escolher uma semana no gráfico de temperatura e pressão, as ações legislativas devem aparecer em 2 grupos:

- Um grupo principal, sempre visível, com os eventos indexados
- Um grupo secundário, sempre oculto e com um botão de "ver", com os eventos não indexados