### PR TITLE
Evita que dados de proposições de outros paineis acessados sejam mostrados no painel selecionado

### DIFF
--- a/src/app/home/selecao-painel/selecao-painel.component.html
+++ b/src/app/home/selecao-painel/selecao-painel.component.html
@@ -3,7 +3,7 @@
     <p>
       Nos painéis, utilizamos o aprendizado de máquina e a ciência de dados para coletar informações da Câmara dos Deputados e do Senado Federal. Com isso, identificamos a ação legislativa das proposições, para aferir a temperatura, o modo como o conteúdo é alterado e os atores nesse processo.
 
-      Hoje, possuímos <strong>{{ interesses.length }} painéis ativos</strong>.
+      Hoje, possuímos <strong>{{ interesses?.length }} painéis ativos</strong>.
     </p>
     <h2 class="text-center my-4">Selecione o painel desejado</h2>
     <div class="d-flex justify-content-center">
@@ -12,9 +12,9 @@
           *ngFor="let interesse of interesses"
           class="col-sm-6 col-md-3">
           <a
-            [routerLink]="'/' + interesse.interesse"
+            [routerLink]="'/' + interesse?.interesse"
             class="btn btn-outline-dark btn-block paineis-selecao">
-            {{ interesse.nome_interesse }}
+            {{ interesse?.nome_interesse }}
           </a>
         </div>
       </div>

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -31,7 +31,7 @@
           [barraClasse]="'bg-temperatura'"
           [valor]="proposicao?.ultima_temperatura"
           [exibirLabel]="true"
-          [max]="maxTemperatura"></app-progress>
+          [max]="proposicao?.max_temperatura_interesse"></app-progress>
       </a>
     </div>
     <div class="space-between-bars">

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
@@ -15,7 +15,6 @@ import { ProposicaoLista } from 'src/app/shared/models/proposicao.model';
 export class CardProposicaoComponent implements OnInit {
   @Input() id: number;
   @Input() proposicao: ProposicaoLista;
-  @Input() maxTemperatura: number;
 
   constructor() {}
 

--- a/src/app/proposicoes/proposicoes.component.html
+++ b/src/app/proposicoes/proposicoes.component.html
@@ -83,8 +83,7 @@
         class="mt-3">
         <app-card-proposicao
           [proposicao]="proposicao"
-          [id]="getProposicaoPosition(i, 20, p)"
-          [maxTemperatura]="maxTemperatura?.max_temperatura_periodo"></app-card-proposicao>
+          [id]="getProposicaoPosition(i, 20, p)"></app-card-proposicao>
       </div>
       <pagination-template
         #pag="paginationApi"

--- a/src/app/proposicoes/proposicoes.component.html
+++ b/src/app/proposicoes/proposicoes.component.html
@@ -20,8 +20,7 @@
         class="mt-3">
         <app-card-proposicao
           [proposicao]="proposicao"
-          [id]="getProposicaoPosition(i, 20, p)"
-          [maxTemperatura]="maxTemperatura?.max_temperatura_periodo"></app-card-proposicao>
+          [id]="getProposicaoPosition(i, 20, p)"></app-card-proposicao>
       </div>
     </div>
   </div>

--- a/src/app/proposicoes/proposicoes.component.ts
+++ b/src/app/proposicoes/proposicoes.component.ts
@@ -1,11 +1,10 @@
 import { AfterContentInit, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 
-import { BehaviorSubject, forkJoin, Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { skip, takeUntil } from 'rxjs/operators';
 
 import { ProposicoesListaService } from '../shared/services/proposicoes-lista.service';
-import { ProposicoesService } from '../shared/services/proposicoes.service';
 import { ProposicaoLista } from '../shared/models/proposicao.model';
 import { MaximaTemperaturaProposicao } from '../shared/models/proposicoes/maximaTemperaturaProposicao.model';
 import { indicate } from '../shared/functions/indicate.function';
@@ -23,13 +22,11 @@ export class ProposicoesComponent implements OnInit, OnDestroy, AfterContentInit
   interesse: string;
   proposicoes: ProposicaoLista[];
   proposicoesDestaque: ProposicaoLista[];
-  maxTemperatura: MaximaTemperaturaProposicao;
   orderByProp: string;
   p = 1;
 
   constructor(
     private proposicoesListaService: ProposicoesListaService,
-    private proposicoesService: ProposicoesService,
     private activatedRoute: ActivatedRoute,
     private cdRef: ChangeDetectorRef,
     private router: Router
@@ -40,7 +37,6 @@ export class ProposicoesComponent implements OnInit, OnDestroy, AfterContentInit
       .pipe(takeUntil(this.unsubscribe))
       .subscribe(params => {
         this.interesse = params.get('interesse');
-        this.getMaxTemperatura(this.interesse);
         this.getProposicoes(this.interesse);
       });
     this.activatedRoute.queryParams
@@ -75,15 +71,6 @@ export class ProposicoesComponent implements OnInit, OnDestroy, AfterContentInit
         this.proposicoes = proposicoes.filter(p => (typeof p.destaques !== 'undefined' && p.destaques.length === 0));
         this.proposicoesDestaque = proposicoes.filter(p => (typeof p.destaques !== 'undefined' && p.destaques.length !== 0));
         this.isLoading.next(false);
-      });
-  }
-
-  getMaxTemperatura(interesse: string) {
-    this.proposicoesService.getMaximaTemperaturaProposicoes(interesse)
-      .pipe(
-        takeUntil(this.unsubscribe)
-      ).subscribe(maxTemperatura => {
-        this.maxTemperatura = maxTemperatura;
       });
   }
 

--- a/src/app/shared/models/atorAgregado.model.ts
+++ b/src/app/shared/models/atorAgregado.model.ts
@@ -18,4 +18,5 @@ export interface AtorAgregado {
   casa_autor: string;
   quantidade_tweets: number;
   governismo: number;
+  interesse: string;
 }

--- a/src/app/shared/models/proposicao.model.ts
+++ b/src/app/shared/models/proposicao.model.ts
@@ -69,6 +69,7 @@ export interface ProposicaoLista {
   anotacao_data_ultima_modificacao: Date;
   resumo_progresso: ProgressoProposicao[];
   destaques: any;
+  max_temperatura_interesse: number;
 }
 
 export interface TramitacaoProposicao {

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -83,17 +83,19 @@ export class ProposicoesListaService {
       [
         this.proposicoesService.getProposicoes(interesse),
         this.proposicoesService.getUltimaTemperaturaProposicoes(interesse),
+        this.proposicoesService.getMaximaTemperaturaProposicoes(interesse),
         this.pressaoService.getUltimaPressaoProposicoes(interesse),
         this.proposicoesService.getDataUltimoInsightProposicoes(interesse),
-        this.progressoService.getProgressoProposicoes(interesse)
+        this.progressoService.getProgressoProposicoes(interesse),
       ]
     )
       .subscribe(data => {
         const proposicoes: any = data[0];
         const ultimaTemperatura: any = data[1];
-        const ultimaPressao: any = data[2];
-        const dataUltimoInsight: any = data[3];
-        const progresso: any = data[4];
+        const maxTemperaturaInteresse: any = data[2];
+        const ultimaPressao: any = data[3];
+        const dataUltimoInsight: any = data[4];
+        const progresso: any = data[5];
 
         const progressos = this.processaProgresso(progresso);
 
@@ -105,6 +107,7 @@ export class ProposicoesListaService {
           anotacao_data_ultima_modificacao: this.getProperty(dataUltimoInsight.find(p => a.id_leggo === p.id_leggo),
             'anotacao_data_ultima_modificacao'),
           resumo_progresso: progressos[a.id_leggo],
+          max_temperatura_interesse: maxTemperaturaInteresse.max_temperatura_periodo,
           ...a
         }));
 

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -15,7 +15,7 @@ export class ProposicoesListaService {
 
   private proposicoes = new BehaviorSubject<Array<ProposicaoLista>>([]);
   private proposicoesFiltered = new BehaviorSubject<Array<ProposicaoLista>>([]);
-  private proposicoesDestaque = new BehaviorSubject<Array<ProposicaoLista>>([]);
+  private interesse: string;
 
   private orderBy = new BehaviorSubject<string>('');
   readonly ORDER_BY_PADRAO = 'maior-temperatura';
@@ -69,12 +69,16 @@ export class ProposicoesListaService {
         }))
       .subscribe(res => {
         if (this.proposicoes.value.length !== 0) {
-          this.proposicoesFiltered.next(res);
+          if (this.interesse === this.proposicoes.value[0].interesse[0].interesse) {
+            this.proposicoesFiltered.next(res);
+          }
         }
       });
   }
 
   getProposicoes(interesse: string): Observable<ProposicaoLista[]> {
+    this.interesse = interesse;
+
     forkJoin(
       [
         this.proposicoesService.getProposicoes(interesse),
@@ -131,10 +135,6 @@ export class ProposicoesListaService {
     } else {
       return objeto[property];
     }
-  }
-
-  private isDestaque(prop: any) {
-    return (typeof prop.destaques !== 'undefined' && prop.destaques.length !== 0);
   }
 
   search(filtro: any) {


### PR DESCRIPTION
## Mudanças
- Corrige erro no componente de seleção dos paineis
-  Evita que lista de parlamentares acessada em outro painel seja exibida no painel atual
-  Evita carregamento paralelo do valor máximo da temperatura de proposições do interesse
- Evita que barra de temperatura recarregue sempre que a página de proposições é acessada

## Flags
- closes #262 