### PR TITLE
Altera consulta do governismo usando serviço dos parlamentares em exercício

### DIFF
--- a/src/app/shared/models/entidade.model.ts
+++ b/src/app/shared/models/entidade.model.ts
@@ -5,4 +5,5 @@ export interface Entidade {
   nome_autor: string;
   partido: string;
   uf: string;
+  governismo: number;
 }

--- a/src/app/shared/models/proposicao.model.ts
+++ b/src/app/shared/models/proposicao.model.ts
@@ -2,9 +2,7 @@ import { ProgressoProposicao } from './proposicoes/progressoProposicao.model';
 
 interface InteresseProposicao {
   interesse: string;
-  nome_interesse: string;
   temas: string[];
-  slug_temas: string[];
   apelido: string;
   advocacy_link: string;
   tipo_agenda: string;
@@ -26,20 +24,13 @@ interface AutorProposicao {
 }
 
 interface EtapasProposicao {
-  id: number;
-  id_ext: number;
   casa: string;
   sigla: string;
   data_apresentacao: string;
-  ano: number;
-  sigla_tipo: string;
   regime_tramitacao: string;
   forma_apreciacao: string;
   ementa: string;
   url: string;
-  casa_origem: string;
-  em_pauta: string;
-  pauta_historico: any;
   relatoria: any;
   comissoes_passadas: string[];
   resumo_tramitacao: TramitacaoProposicao[];
@@ -58,7 +49,6 @@ export interface Proposicao {
 }
 
 export interface ProposicaoLista {
-  id: number;
   interesse: InteresseProposicao[];
   id_leggo: string;
   etapas: EtapasProposicao[];

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -153,13 +153,6 @@ export class ParlamentaresService {
           }
           p.atividade_twitter = this.normalizarAtividade(p.atividade_twitter, Math.min(...tweets), Math.max(...tweets));
           p.peso_politico = this.pesoService.normalizarPesoPolitico(p.peso_politico, Math.max(...pesosPoliticos));
-          if (p.peso_autorias_projetos) {
-            if (p.peso_autorias_projetos % 1 !== 0) {
-              p.peso_autorias_projetos = +p.peso_autorias_projetos.toFixed(2);
-            }
-          } else {
-            p.peso_autorias_projetos = 0;
-          }
           p.governismo = this.normalizarAtividade(p.governismo, Math.min(...valoresGovernismo), Math.max(...valoresGovernismo));
         });
 

--- a/src/app/shared/services/parlamentares.service.ts
+++ b/src/app/shared/services/parlamentares.service.ts
@@ -10,7 +10,6 @@ import { PesoPoliticoService } from 'src/app/shared/services/peso-politico.servi
 import { RelatoriaService } from 'src/app/shared/services/relatoria.service';
 import { EntidadeService } from 'src/app/shared/services/entidade.service';
 import { TwitterService } from 'src/app/shared/services/twitter.service';
-import { GovernismoService } from './governismo.service';
 
 @Injectable({
   providedIn: 'root'
@@ -31,8 +30,7 @@ export class ParlamentaresService {
     private pesoService: PesoPoliticoService,
     private relatoriaService: RelatoriaService,
     private entidadeService: EntidadeService,
-    private twitterService: TwitterService,
-    private governismoService: GovernismoService
+    private twitterService: TwitterService
   ) {
 
     this.parlamentares
@@ -96,8 +94,7 @@ export class ParlamentaresService {
         this.relatoriaService.getAtoresRelatores(interesse, tema, destaque),
         this.pesoService.getPesoPolitico(),
         this.twitterService.getAtividadeTwitter(interesse, tema, dataInicial, dataFinal, destaque),
-        this.autoriaService.getAutoriasAgregadasProjetos(interesse, tema, destaque),
-        this.governismoService.getGovernismo()
+        this.autoriaService.getAutoriasAgregadasProjetos(interesse, tema, destaque)
       ]
     )
       .subscribe(data => {
@@ -117,7 +114,6 @@ export class ParlamentaresService {
           ...pesoPolitico.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
           ...twitter.find(p => a.id_autor_parlametria === +p.id_parlamentar_parlametria),
           ...autoriasProjetos.find(p => a.id_autor_parlametria === p.id_autor_parlametria),
-          ...governismo.find(p => a.id_autor_parlametria === p.id_parlamentar_parlametria),
           ...a
         }));
 


### PR DESCRIPTION
## Mudanças
- Passa a consultar governismo via o novo endpoint de parlamentares 
- Remove do model atributos não usados

## Flags 
- Depende da versão do backend: https://github.com/parlametria/leggo-backend/pull/334