### PR TITLE
Evita erro quando a ementa tem o valor null

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/ementas/ementas.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/ementas/ementas.component.ts
@@ -35,7 +35,7 @@ export class EmentasComponent implements OnInit {
   }
 
   getResumo(texto: string) {
-    if (texto !== undefined) {
+    if (texto !== undefined && texto !== null) {
       if (texto.length > this.LIMITE_RESUMO) {
         return texto.substring(0, this.LIMITE_RESUMO) + '...';
       }
@@ -44,7 +44,7 @@ export class EmentasComponent implements OnInit {
   }
 
   getTemEmentaResumida(texto: string): boolean {
-    if (texto !== undefined) {
+    if (texto !== undefined && texto !== null) {
       return texto.length > this.LIMITE_RESUMO;
     }
   }


### PR DESCRIPTION
## Mudanças
- Evita o erro: 
`ERROR TypeError: texto is null`
para proposições como http://localhost:4200/transparencia-e-integridade/proposicoes/48cae6b0c2d1addfc189aa343d7b084c/temperatura-pressao