### PR TITLE
Resolve posição da barra ao selecionar semana no gráfico de temp/pressão

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -357,11 +357,16 @@ export class VisTemperaturaPressaoComponent implements OnInit {
           .style('display', null)
           .attr('cx', this.x(dados[i - 1].data))
           .attr('cy', this.yPressao(dados[i - 1].valorPressao));
-      } else {
+      } else if (typeof dados[i - 2] !== 'undefined') {
         markerPressao
           .style('display', null)
           .attr('cx', this.x(dados[i - 1].data))
           .attr('cy', this.yPressao(dados[i - 2].valorPressao));
+      } else  {
+        markerPressao
+          .style('display', null)
+          .attr('cx', this.x(dados[i - 1].data))
+          .attr('cy', this.yPressao(0));
       }
       bar
         .style('display', null)


### PR DESCRIPTION
Quando não há dados de pressão na primeira semana do gráfico a linha tracejada.
O teste de valor undefined resolve esse bug.