### PR TITLE
Diferencia visualmente as proposições apensadas

### DIFF
--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -33,8 +33,11 @@
       <span class="proposicao-title text-muted">
         {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}
       </span>
-      <p>
-        <span class="text-muted">Apensada à proposição principal</span>&nbsp;<a href="#">PL 2949/2020</a>
+      <p *ngIf="!getEhApensadaExterna()">
+        <span class="text-muted">Apensada à proposição principal</span>&nbsp;<a [routerLink]="[getLinkInterno()]">{{ getNomeApensada() }}</a>
+      </p>
+      <p *ngIf="getEhApensadaExterna()">
+        <span class="text-muted">Apensada à <a [href]="getLinkExterno()" target="_blank">proposição principal <span class="icon-external-link"></span></a></span>
       </p>
     </div>
     <div [hidden]="getEhApensada()">

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -1,5 +1,9 @@
-<div class="card mb-2">
-  <div class="card-header d-flex mx-1">
+<div
+  class="card mb-2"
+  [class.card-muted]="getEhApensada()">
+  <div
+    class="card-header d-flex mx-1"
+    [class.card-header-muted]="getEhApensada()">
     <span
       class="cracha text-muted temas"
       [ngbPopover]="popTemas"
@@ -14,128 +18,138 @@
     </span>
   </div>
   <div class="card-body">
-    <a [routerLink]="[proposicao.id_leggo]">
-      <span class="proposicao-title">
-        {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}
-        <span *ngIf="proposicao?.interesse[0]?.apelido && proposicao?.interesse[0]?.apelido !== 'nan'">
-          -
+    <div [hidden]="getEhApensada()">
+      <a [routerLink]="[proposicao.id_leggo]">
+        <span class="proposicao-title">
+          {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}
+          <span *ngIf="proposicao?.interesse[0]?.apelido && proposicao?.interesse[0]?.apelido !== 'nan'">
+            -
           {{ proposicao?.interesse[0]?.apelido }}
+          </span>
         </span>
+      </a>
+    </div>
+    <div [hidden]="!getEhApensada()">
+      <span class="proposicao-title text-muted">
+        {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.sigla }}
       </span>
-    </a>
-    <p
-      *ngIf="proposicao?.locaisProposicao[0]"
-      class="proposicao-info text-muted">
-      {{ getArtigoSiglaLocal(proposicao?.locaisProposicao[0]) }}
-      <button
-        class="btn btn-in-text btn-link"
-        [ngbPopover]="popLocalProposicao"
-        [autoClose]="'outside'">
-        {{ getSiglaLocal(proposicao?.locaisProposicao[0]) }}
-      </button>
-      <ng-template #popLocalProposicao>
-        {{ getNomeLocal(proposicao?.locaisProposicao[0]) }}
-      </ng-template>
-      desde
-      {{ proposicao?.locaisProposicao[0].data_ultima_situacao | date:'dd/MM/yyyy' }}
-    </p>
-    <div class="row no-gutters align-items-center mb-1">
-      <div class="col">
-        <a [routerLink]="[proposicao.id_leggo + '/temperatura-pressao']">
-          <app-progress
-            class="pointer"
-            [label]="'Temperatura da semana: ' + proposicao?.ultima_temperatura"
-            [barraClasse]="'bg-temperatura'"
-            [valor]="proposicao?.ultima_temperatura"
-            [exibirLabel]="true"
-            [max]="proposicao?.max_temperatura_interesse"></app-progress>
-        </a>
-      </div>
-      <div class="col-2 col-sm-1 text-center">
-        <span
-          class="badge badge-color-white bg-temperatura badge-em-alta">
-          <span
-            class="icon-em-alta"
-            ngbPopover="Temperatura em alta"
-            [autoClose]="'outside'"
-            *ngIf="proposicao?.ultima_temperatura > proposicao?.temp_quinze_dias"></span>
-        </span>
-      </div>
+      <p>
+        <span class="text-muted">Apensada à proposição principal</span>&nbsp;<a href="#">PL 2949/2020</a>
+      </p>
     </div>
-    <div class="row no-gutters align-items-center mb-1">
-      <div class="space-between-bars col">
-        <a [routerLink]="[proposicao.id_leggo + '/temperatura-pressao']">
-          <app-progress
-            class="pointer"
-            [label]="'Pressão da semana: ' + (!proposicao?.ultima_pressao ? '0' : (proposicao?.ultima_pressao * 100))"
-            [barraClasse]="'bg-pressao'"
-            [valor]="proposicao?.ultima_pressao"
-            [exibirLabel]="true"></app-progress>
-        </a>
-      </div>
-      <div class="col-2 col-sm-1 text-center">
-        <span
-          class="badge badge-color-white bg-pressao badge-em-alta">
-          <span
-            class="icon-em-alta"
-            ngbPopover="Pressão em alta"
-            [autoClose]="'outside'"
-            *ngIf="proposicao?.ultima_pressao > proposicao?.pressao_oito_dias"></span>
-        </span>
-      </div>
-    </div>
-    <div class="tags mt-3">
-      <div *ngIf="proposicao?.destaques.length || proposicao?.interesse[0]?.advocacy_link !== 'nan'">
-        <app-destaques-proposicao
-          [destaques]="destaques"
-          *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
-        <span
-          class="tag badge badge-gray"
-          *ngIf="proposicao?.interesse[0]?.advocacy_link && proposicao?.interesse[0]?.advocacy_link !== 'nan'"
-          [ngbPopover]="popAdvocacy"
+    <div [hidden]="getEhApensada()">
+      <p
+        *ngIf="proposicao?.locaisProposicao[0]"
+        class="proposicao-info text-muted">
+        {{ getArtigoSiglaLocal(proposicao?.locaisProposicao[0]) }}
+        <button
+          class="btn btn-in-text btn-link"
+          [ngbPopover]="popLocalProposicao"
           [autoClose]="'outside'">
-          advocacy box
-        </span>
-        <ng-template #popAdvocacy>
-          Existem notas técnicas de OSCs disponíveis para esta proposição.
-          <div class="text-right">
-            <a
-              href="{{proposicao?.interesse[0]?.advocacy_link}}"
-              target="_blank"
-              class="btn btn-link btn-sm">
-              Ver notas
-            </a>
-          </div>
+          {{ getSiglaLocal(proposicao?.locaisProposicao[0]) }}
+        </button>
+        <ng-template #popLocalProposicao>
+          {{ getNomeLocal(proposicao?.locaisProposicao[0]) }}
         </ng-template>
+        desde
+      {{ proposicao?.locaisProposicao[0].data_ultima_situacao | date:'dd/MM/yyyy' }}
+      </p>
+      <div class="row no-gutters align-items-center mb-1">
+        <div class="col">
+          <a [routerLink]="[proposicao.id_leggo + '/temperatura-pressao']">
+            <app-progress
+              class="pointer"
+              [label]="'Temperatura da semana: ' + proposicao?.ultima_temperatura"
+              [barraClasse]="'bg-temperatura'"
+              [valor]="proposicao?.ultima_temperatura"
+              [exibirLabel]="true"
+              [max]="proposicao?.max_temperatura_interesse"></app-progress>
+          </a>
+        </div>
+        <div class="col-2 col-sm-1 text-center">
+          <span class="badge badge-color-white bg-temperatura badge-em-alta">
+            <span
+              class="icon-em-alta"
+              ngbPopover="Temperatura em alta"
+              [autoClose]="'outside'"
+              *ngIf="proposicao?.ultima_temperatura > proposicao?.temp_quinze_dias"></span>
+          </span>
+        </div>
       </div>
-      <div *ngIf="!proposicao?.destaques.length">
-        <span
-          *ngIf="!['Ordinária', 'Indefinido'].includes(proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao)"
-          class="tag"
-          [ngClass]="getClassRegimeTramitacao(proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao)"
-          ngbPopover="Regime de tramitação"
-          [autoClose]="'outside'">
-          {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao }}
-        </span>
-        <span
-          *ngIf="proposicao?.etapas[proposicao?.etapas.length - 1]?.status !== 'Ativa'"
-          class="tag badge badge-gray"
-          ngbPopover="A proposição foi finalizada"
-          [autoClose]="'outside'">
-          {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.status }}
-        </span>
+      <div class="row no-gutters align-items-center mb-1">
+        <div class="space-between-bars col">
+          <a [routerLink]="[proposicao.id_leggo + '/temperatura-pressao']">
+            <app-progress
+              class="pointer"
+              [label]="'Pressão da semana: ' + (!proposicao?.ultima_pressao ? '0' : (proposicao?.ultima_pressao * 100))"
+              [barraClasse]="'bg-pressao'"
+              [valor]="proposicao?.ultima_pressao"
+              [exibirLabel]="true"></app-progress>
+          </a>
+        </div>
+        <div class="col-2 col-sm-1 text-center">
+          <span class="badge badge-color-white bg-pressao badge-em-alta">
+            <span
+              class="icon-em-alta"
+              ngbPopover="Pressão em alta"
+              [autoClose]="'outside'"
+              *ngIf="proposicao?.ultima_pressao > proposicao?.pressao_oito_dias"></span>
+          </span>
+        </div>
       </div>
-      <div class="d-flex">
-        <div
-          *ngFor="let f of proposicao?.resumo_progresso"
-          class="fase pointer"
-          [ngClass]="getClassFaseProgresso(f)"
-          [ngbPopover]="popProgresso"
-          [autoClose]="'outside'">
-          <ng-template #popProgresso>
-            <span *ngIf="f?.fase_global_local">{{ f?.fase_global_local }}</span>
-            <span *ngIf="!f?.fase_global_local">{{ f?.fase_global }}</span>
+      <div class="tags mt-3">
+        <div *ngIf="proposicao?.destaques.length || proposicao?.interesse[0]?.advocacy_link !== 'nan'">
+          <app-destaques-proposicao
+            [destaques]="destaques"
+            *ngFor="let destaques of proposicao?.destaques"></app-destaques-proposicao>
+          <span
+            class="tag badge badge-gray"
+            *ngIf="proposicao?.interesse[0]?.advocacy_link && proposicao?.interesse[0]?.advocacy_link !== 'nan'"
+            [ngbPopover]="popAdvocacy"
+            [autoClose]="'outside'">
+            advocacy box
+          </span>
+          <ng-template #popAdvocacy>
+            Existem notas técnicas de OSCs disponíveis para esta proposição.
+            <div class="text-right">
+              <a
+                href="{{proposicao?.interesse[0]?.advocacy_link}}"
+                target="_blank"
+                class="btn btn-link btn-sm">
+                Ver notas
+              </a>
+            </div>
           </ng-template>
+        </div>
+        <div *ngIf="!proposicao?.destaques.length">
+          <span
+            *ngIf="!['Ordinária', 'Indefinido'].includes(proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao)"
+            class="tag"
+            [ngClass]="getClassRegimeTramitacao(proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao)"
+            ngbPopover="Regime de tramitação"
+            [autoClose]="'outside'">
+            {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.regime_tramitacao }}
+          </span>
+          <span
+            *ngIf="proposicao?.etapas[proposicao?.etapas.length - 1]?.status !== 'Ativa'"
+            class="tag badge badge-gray"
+            ngbPopover="A proposição foi finalizada"
+            [autoClose]="'outside'">
+            {{ proposicao?.etapas[proposicao?.etapas.length - 1]?.status }}
+          </span>
+        </div>
+        <div class="d-flex">
+          <div
+            *ngFor="let f of proposicao?.resumo_progresso"
+            class="fase pointer"
+            [ngClass]="getClassFaseProgresso(f)"
+            [ngbPopover]="popProgresso"
+            [autoClose]="'outside'">
+            <ng-template #popProgresso>
+              <span *ngIf="f?.fase_global_local">{{ f?.fase_global_local }}</span>
+              <span *ngIf="!f?.fase_global_local">{{ f?.fase_global }}</span>
+            </ng-template>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.scss
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.scss
@@ -29,3 +29,12 @@ $base-padding: 0.5rem;
   font-size: 100%;
   border-radius: 50%;
 }
+
+.card-muted {
+  border-color: #adb5bd;
+  background-color: #f8f9fa;
+}
+
+.card-header-muted {
+  background-color: #f8f9fa;
+}

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
@@ -105,7 +105,40 @@ export class CardProposicaoComponent implements OnInit {
   }
 
   getEhApensada() {
-    return this.proposicao.apensadas.length;
+    return this.proposicao.apensadas.length > 0;
+  }
+
+  getEhApensadaExterna() {
+    return (typeof this.proposicao.apensadas[0] !== 'undefined' && this.proposicao.apensadas[0].id_leggo_principal === null);
+  }
+
+  getLinkExterno() {
+    if (typeof this.proposicao.apensadas[0] !== 'undefined' && this.proposicao.apensadas[0].id_leggo_principal === null) {
+      if (this.proposicao.apensadas[0].casa_principal === 'camara') {
+        return 'http://www.camara.gov.br/proposicoesWeb/fichadetramitacao?idProposicao=' + this.proposicao.apensadas[0].id_ext_principal;
+      } else {
+        return 'https://www25.senado.leg.br/web/atividade/materias/-/materia/' + this.proposicao.apensadas[0].id_ext_principal;
+      }
+    }
+    return '#';
+  }
+
+  getLinkInterno() {
+    if (typeof this.proposicao.apensadas[0] !== 'undefined' && this.proposicao.apensadas[0].id_leggo_principal !== null) {
+      return this.proposicao.apensadas[0].id_leggo_principal;
+    }
+    return './';
+  }
+
+  getNomeApensada() {
+    if (typeof this.proposicao.apensadas[0] !== 'undefined' && this.proposicao.apensadas[0].proposicao_principal !== null) {
+      if (this.proposicao.apensadas[0].casa_principal === 'camara') {
+        return this.proposicao.apensadas[0].proposicao_principal.sigla_camara;
+      } else {
+        return this.proposicao.apensadas[0].proposicao_principal.sigla_senado;
+      }
+    }
+    return './';
   }
 
   private ordenaProgresso(resumoProgresso) {

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
@@ -104,6 +104,10 @@ export class CardProposicaoComponent implements OnInit {
     }
   }
 
+  getEhApensada() {
+    return this.proposicao.apensadas.length;
+  }
+
   private ordenaProgresso(resumoProgresso) {
     return ordenaProgressoProposicao(resumoProgresso);
   }

--- a/src/app/proposicoes/filtro-proposicoes/filtro-proposicoes.component.ts
+++ b/src/app/proposicoes/filtro-proposicoes/filtro-proposicoes.component.ts
@@ -132,7 +132,8 @@ export class FiltroProposicoesComponent implements OnInit, AfterContentInit, OnD
       nome: this.proposicaoPesquisada,
       status: this.statusSelecionado,
       tema: this.temaSelecionado,
-      local: this.localSelecionado
+      local: this.localSelecionado,
+      semApensada: true
     };
     this.filterChange.emit(this.filtro);
   }

--- a/src/app/proposicoes/proposicoes.component.ts
+++ b/src/app/proposicoes/proposicoes.component.ts
@@ -70,8 +70,8 @@ export class ProposicoesComponent implements OnInit, OnDestroy, AfterContentInit
         indicate(this.isLoading),
         takeUntil(this.unsubscribe)
       ).subscribe(proposicoes => {
-        this.proposicoes = proposicoes.filter(p => !p.isDestaque);
-        this.proposicoesDestaque = proposicoes.filter(p => p.isDestaque);
+        this.proposicoes = proposicoes.filter(p => (!p.isDestaque && p.apensadas.length > 0));
+        this.proposicoesDestaque = proposicoes.filter(p => (p.isDestaque && p.apensadas.length < 1));
 
         if (proposicoes.length <= (this.PROPOSICOES_POR_PAGINA * (this.p - 1))) {
           this.pageChange(1); // volta para a primeira página com o novo resultado do filtro

--- a/src/app/proposicoes/proposicoes.component.ts
+++ b/src/app/proposicoes/proposicoes.component.ts
@@ -70,7 +70,7 @@ export class ProposicoesComponent implements OnInit, OnDestroy, AfterContentInit
         indicate(this.isLoading),
         takeUntil(this.unsubscribe)
       ).subscribe(proposicoes => {
-        this.proposicoes = proposicoes.filter(p => (!p.isDestaque && p.apensadas.length > 0));
+        this.proposicoes = proposicoes.filter(p => (!p.isDestaque || p.apensadas.length > 0));
         this.proposicoesDestaque = proposicoes.filter(p => (p.isDestaque && p.apensadas.length < 1));
 
         if (proposicoes.length <= (this.PROPOSICOES_POR_PAGINA * (this.p - 1))) {

--- a/src/app/shared/models/proposicao.model.ts
+++ b/src/app/shared/models/proposicao.model.ts
@@ -38,6 +38,14 @@ interface EtapasProposicao {
   status: string;
 }
 
+interface Apensada {
+  id_leggo_principal: string;
+  interesse_principal: string;
+  id_ext_principal: number;
+  casa_principal: string;
+  proposicao_principal: any;
+}
+
 export interface LocalProposicao {
   casa_ultimo_local: string;
   data_ultima_situacao: Date;
@@ -74,6 +82,7 @@ export interface ProposicaoLista {
   max_temperatura_interesse: number;
   isDestaque: boolean;
   locaisProposicao: LocalProposicao[];
+  apensadas: Apensada[];
 }
 
 export interface TramitacaoProposicao {

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -25,6 +25,7 @@ export class ProposicoesListaService {
 
   readonly STATUS_PADRAO = 'tramitando';
   readonly TIPO_LOCAL_PADRAO = 'geral';
+  readonly APENSADAS_PADRAO = true;
 
   private filtro = new BehaviorSubject<any>({});
 
@@ -162,6 +163,7 @@ export class ProposicoesListaService {
   search(filtro: any) {
     if (filtro.status === undefined || filtro.status === '') {
       filtro.status = this.STATUS_PADRAO;
+      filtro.semApensada = this.APENSADAS_PADRAO;
     }
     this.filtro.next(filtro);
   }
@@ -178,6 +180,11 @@ export class ProposicoesListaService {
     const status = filtro.status;
     const tema = filtro.tema;
     const local = filtro.local;
+    let semApensada = filtro.semApensada;
+    // Condição fixa para exibir apensadas no resultado:
+    if (nome) {
+      semApensada = false;
+    }
 
     return proposicoes.filter(p => {
       let filtered = true;
@@ -204,6 +211,11 @@ export class ProposicoesListaService {
       filtered =
         local && filtered
           ? this.matchLocal(p.locaisProposicao, local)
+          : filtered;
+
+      filtered =
+        semApensada && filtered
+          ? p.apensadas.length < 1
           : filtered;
 
       return filtered;


### PR DESCRIPTION
## Mudanças

Proposições apensadas são exibidas com um card diferente e somente quando se pesquisa por nome.

- Proposições apensadas não devem ser exibidas por padrão
- Proposições apensadas devem ser exibidas ao se pesquisar por nome
- Proposições apensadas não devem aperecer em destaque, sempre estão no grupo das "demais"
- Proposições apensadas devem apresentar um link para a principal, mesmo que esta não esteja sendo monitorada 