### PR TITLE
Altera campos para gráfico de pressão

### DIFF
--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -84,7 +84,7 @@
           <a [routerLink]="[proposicao.id_leggo + '/temperatura-pressao']">
             <app-progress
               class="pointer"
-              [label]="'Pressão da semana: ' + (!proposicao?.ultima_pressao ? '0' : (proposicao?.ultima_pressao * 100))"
+              [label]="'Pressão da semana: ' + (!proposicao?.ultima_pressao ? '0' : proposicao?.ultima_pressao | number : '1.0-2')"
               [barraClasse]="'bg-pressao'"
               [valor]="proposicao?.ultima_pressao"
               [exibirLabel]="true"></app-progress>

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.html
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.html
@@ -87,6 +87,7 @@
               [label]="'Pressão da semana: ' + (!proposicao?.ultima_pressao ? '0' : proposicao?.ultima_pressao | number : '1.0-2')"
               [barraClasse]="'bg-pressao'"
               [valor]="proposicao?.ultima_pressao"
+              [max]="100"
               [exibirLabel]="true"></app-progress>
           </a>
         </div>

--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
@@ -11,11 +11,14 @@
         Semana de {{ getSemanaString(filtro?.data) }}
       </div>
       <div class="mb-3">
-        <p>
+        <p *ngIf="filtro?.valorTemperatura !== null">
           <strong class="color-temperatura">
             {{ filtro?.valorTemperatura | number : '1.0-1' }}°C
           </strong>
           de temperatura
+        </p>
+        <p *ngIf="filtro?.valorTemperatura === null">
+          Dados de <strong class="color-temperatura">temperatura</strong> não disponíveis
         </p>
       </div>
       <p *ngIf="filtro?.valorPressao !== null">

--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
@@ -55,8 +55,8 @@ export class TemperaturaPressaoComponent implements OnInit {
   }
 
   getSemanaString(data) {
-    const dataInicial = data.clone().subtract(7, 'days');
-    const dataFinal = data.clone();
+    const dataInicial = data.clone();
+    const dataFinal = data.clone().add(7, 'days');
     return `${dataInicial.format('D')} de ${dataInicial.format('MMM')} a
       ${dataFinal.format('D')} de ${dataFinal.format('MMM')}`;
   }

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -164,10 +164,14 @@ export class VisTemperaturaPressaoComponent implements OnInit {
         a.popularity = parseFloat(a.popularity.toFixed(1));
         return a;
       });
-      const temperatura: any = data[1];
+      let temperatura: any = data[1];
       const temperaturaMax: any = data[2];
       let temperaturaPressao;
       if (pressao.length > temperatura.length) {
+        temperatura = data[1].map(a => {
+          a.periodo = moment(a.periodo).add(7, 'days').format('YYYY-MM-DD');
+          return a;
+        });
         temperaturaPressao = pressao.map(a => ({
           data: moment(this.getProperty(temperatura.find(p => a.date === p.periodo),
             'periodo') ?? a.date),

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -22,6 +22,8 @@ import { TemperaturaService } from 'src/app/shared/services/temperatura.service'
 
 import { Pressao } from 'src/app/shared/models/pressao.model';
 
+import { setUpperBound } from 'src/app/shared/functions/utils';
+
 const d3 = Object.assign({}, {
   select,
   selectAll,
@@ -157,35 +159,28 @@ export class VisTemperaturaPressaoComponent implements OnInit {
     forkJoin([
       this.pressaoService.getPressaoList(this.interesse, this.idProposicaoDestaque, dataInicio, dataFim),
       this.temperaturaService.getTemperaturasById(this.interesse, this.idProposicaoDestaque, dataInicio, dataFim),
-      this.temperaturaService.getMaximaTemperatura(this.interesse)
-
     ]).subscribe(data => {
       const pressao: Pressao[] = data[0].map(a => {
         a.popularity = parseFloat(a.popularity.toFixed(1));
         return a;
       });
-      let temperatura: any = data[1];
-      const temperaturaMax: any = data[2];
+      const temperatura: any = data[1];
       let temperaturaPressao;
       if (pressao.length > temperatura.length) {
-        temperatura = data[1].map(a => {
-          a.periodo = moment(a.periodo).add(7, 'days').format('YYYY-MM-DD');
-          return a;
-        });
         temperaturaPressao = pressao.map(a => ({
           data: moment(this.getProperty(temperatura.find(p => a.date === p.periodo),
             'periodo') ?? a.date),
-          valorTemperatura: this.getProperty(temperatura.find(p => a.date === p.periodo),
-            'temperatura_recente') ?? 0,
-          valorPressao: a.popularity
+          valorTemperatura: setUpperBound(this.getProperty(temperatura.find(p => a.date === p.periodo),
+            'temperatura_recente')) ?? null,
+          valorPressao: setUpperBound(a.popularity)
         }));
       } else {
         temperaturaPressao = temperatura.map(a => ({
           data: moment(this.getProperty(pressao.find(p => a.periodo === p.date),
-            'date') ?? a.periodo).add(7, 'days'),
-          valorTemperatura: a.temperatura_recente,
-          valorPressao: this.getProperty(pressao.find(p => a.periodo === p.date),
-            'popularity') ?? null
+            'date') ?? a.periodo),
+          valorTemperatura: setUpperBound(a.temperatura_recente),
+          valorPressao: setUpperBound(this.getProperty(pressao.find(p => a.periodo === p.date),
+            'popularity')) ?? null
         }));
       }
       temperaturaPressao.sort((a, b) => {
@@ -194,19 +189,14 @@ export class VisTemperaturaPressaoComponent implements OnInit {
       if (this.gTemperatura) {
         this.gTemperatura.selectAll('*').remove();
       }
-      this.gTemperatura.call(g => this.atualizarVis(g, temperaturaPressao, temperaturaMax.max_temperatura_periodo));
+      this.gTemperatura.call(g => this.atualizarVis(g, temperaturaPressao));
     });
   }
 
-  private atualizarVis(g, dados, temperaturaMax) {
+  private atualizarVis(g, dados) {
     this.x.domain(d3.extent(dados, (d: any) => d.data));
-    this.yTemperatura.domain([0, temperaturaMax]);
-    const maxPressao = +d3.max(dados, (d: any) => d.valorPressao);
-    if (maxPressao > 100) {
-      this.yPressao.domain([0, maxPressao]);
-    } else {
-      this.yPressao.domain([0, 100]);
-    }
+    this.yTemperatura.domain([0, 100]);
+    this.yPressao.domain([0, 100]);
 
     const lineTemperatura = d3.line()
       .curve(d3.curveMonotoneX)

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -158,7 +158,10 @@ export class VisTemperaturaPressaoComponent implements OnInit {
       this.temperaturaService.getMaximaTemperatura(this.interesse)
 
     ]).subscribe(data => {
-      const pressao: any = data[0];
+      const pressao: any = data[0].map(a => {
+        a.popularity = parseFloat(a.popularity).toFixed(1);
+        return a;
+      });
       const temperatura: any = data[1];
       const temperaturaMax: any = data[2];
       let temperaturaPressao;
@@ -168,7 +171,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
             'periodo') ?? a.date),
           valorTemperatura: this.getProperty(temperatura.find(p => a.date === p.periodo),
             'temperatura_recente') ?? 0,
-          valorPressao: a.trends_max_pressao_principal
+          valorPressao: a.popularity
         }));
       } else {
         temperaturaPressao = temperatura.map(a => ({
@@ -176,7 +179,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
             'date') ?? a.periodo).add(7, 'days'),
           valorTemperatura: a.temperatura_recente,
           valorPressao: this.getProperty(pressao.find(p => a.periodo === p.date),
-            'trends_max_pressao_principal') ?? null
+            'popularity') ?? null
         }));
       }
       temperaturaPressao.sort((a, b) => {

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -246,7 +246,6 @@ export class VisTemperaturaPressaoComponent implements OnInit {
     const colorPressao = d3.scaleSequential(d3.interpolateOranges);
     // Remove último elemento da série de pressão
     const dadosPressao = [...dados];
-    dadosPressao.pop();
     this.gPressao.append('linearGradient')
       .attr('id', 'gradient-pressao')
       .attr('gradientUnits', 'userSpaceOnUse')
@@ -276,18 +275,6 @@ export class VisTemperaturaPressaoComponent implements OnInit {
       .attr('font-size', '0.8rem')
       .text(`Maior pressão`);
 
-    // Linha tracejada pra semana faltante de pressão
-    const dadosFaltando = [];
-    dadosFaltando.push(dados[dados.length - 2]);
-    dadosFaltando.push(dados[dados.length - 1]);
-    this.gPressao.append('line')
-      .attr('x1', this.x(dadosFaltando[0].data))
-      .attr('y1', this.yPressao(dadosFaltando[0].valorPressao))
-      .attr('x2', this.x(dadosFaltando[1].data))
-      .attr('y2', this.yPressao(dadosFaltando[0].valorPressao))
-      .style('stroke', '#cccccc')
-      .style('stroke-width', 3)
-      .style('stroke-dasharray', 4);
 
     this.gTemperatura.append('g')
       .attr('transform', `translate(0, ${this.heightGrafico + 5})`)
@@ -343,7 +330,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
     markerPressao
       .style('display', null)
       .attr('cx', this.x(dados[dados.length - 1].data))
-      .attr('cy', this.yPressao(dados[dados.length - 2].valorPressao));
+      .attr('cy', this.yPressao(dados[dados.length - 1].valorPressao));
     bar
       .style('display', null)
       .attr('transform', `translate(${this.x(dados[dados.length - 1].data)}, 0)`);
@@ -366,7 +353,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
         markerPressao
           .style('display', null)
           .attr('cx', this.x(dados[i - 1].data))
-          .attr('cy', this.yPressao(dados[i - 2].valorPressao));
+          .attr('cy', this.yPressao(dados[i - 1].valorPressao));
       }
       bar
         .style('display', null)

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -20,6 +20,8 @@ import { timeMonday } from 'd3-time';
 import { PressaoService } from 'src/app/shared/services/pressao.service';
 import { TemperaturaService } from 'src/app/shared/services/temperatura.service';
 
+import { Pressao } from 'src/app/shared/models/pressao.model';
+
 const d3 = Object.assign({}, {
   select,
   selectAll,
@@ -158,8 +160,8 @@ export class VisTemperaturaPressaoComponent implements OnInit {
       this.temperaturaService.getMaximaTemperatura(this.interesse)
 
     ]).subscribe(data => {
-      const pressao: any = data[0].map(a => {
-        a.popularity = parseFloat(a.popularity).toFixed(1);
+      const pressao: Pressao[] = data[0].map(a => {
+        a.popularity = parseFloat(a.popularity.toFixed(1));
         return a;
       });
       const temperatura: any = data[1];

--- a/src/app/shared/functions/utils.ts
+++ b/src/app/shared/functions/utils.ts
@@ -1,0 +1,6 @@
+export function setUpperBound(valor: number, valorMax: number = 100) {
+  if (valor > valorMax) {
+    return valorMax;
+  }
+  return valor;
+}

--- a/src/app/shared/models/pressao.model.ts
+++ b/src/app/shared/models/pressao.model.ts
@@ -1,8 +1,10 @@
 export interface Pressao {
-  data: string;
+  date: string;
   trends_max_pressao_principal: number;
   trends_max_pressao_rel: number;
   trends_max_popularity: number;
+  user_count: number;
+  sum_interactions: number;
   twitter_mean_popularity: number;
   popularity: number;
 }

--- a/src/app/shared/services/eventos.service.ts
+++ b/src/app/shared/services/eventos.service.ts
@@ -47,8 +47,7 @@ export class EventosService {
   filtrar(eventos, filtro) {
     if (typeof filtro !== 'undefined' && filtro.data) {
       const dataComparativaInicial = filtro.data.clone();
-      dataComparativaInicial.subtract(7, 'days');
-      const dataComparativaFinal = filtro.data.clone();
+      const dataComparativaFinal = filtro.data.clone().add(7, 'days');
 
       const filtrados = eventos.filter(evento => {
         return (moment(evento.data).isSameOrAfter(dataComparativaInicial) && moment(evento.data).isBefore(dataComparativaFinal));

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -8,6 +8,8 @@ import { LocalProposicao, ProposicaoLista } from '../models/proposicao.model';
 import { PressaoService } from './pressao.service';
 import { ProgressoService } from './progresso.service';
 
+import { setUpperBound } from '../functions/utils';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -106,18 +108,18 @@ export class ProposicoesListaService {
         const progressos = this.processaProgresso(progresso);
 
         const proposicoesLista = proposicoes.map(a => ({
-          ultima_temperatura: this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
-            'ultima_temperatura'),
-          temp_quinze_dias: this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
-            'temp_quinze_dias'),
-          ultima_pressao: this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
-            'ultima_pressao'),
-          pressao_oito_dias: this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
-            'pressao_oito_dias'),
+          ultima_temperatura: setUpperBound(this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
+            'ultima_temperatura')),
+          temp_quinze_dias: setUpperBound(this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
+            'temp_quinze_dias')),
+          ultima_pressao: setUpperBound(this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
+            'ultima_pressao')),
+          pressao_oito_dias: setUpperBound(this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
+            'pressao_oito_dias')),
           anotacao_data_ultima_modificacao: this.getProperty(dataUltimoInsight.find(p => a.id_leggo === p.id_leggo),
             'anotacao_data_ultima_modificacao'),
           resumo_progresso: progressos[a.id_leggo],
-          max_temperatura_interesse: maxTemperaturaInteresse.max_temperatura_periodo,
+          max_temperatura_interesse: setUpperBound(maxTemperaturaInteresse.max_temperatura_periodo),
           isDestaque: this.isDestaque(a),
           ...a
         }));

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  baseUrl: 'https://dev.api.leggo.org.br',
+  baseUrl: 'https://api.leggo.org.br',
   twitterAPIUrl: 'https://leggo-twitter.herokuapp.com',
   perfilUrl: 'https://perfil.parlametria.org.br/api'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  baseUrl: 'https://api.leggo.org.br',
+  baseUrl: 'https://dev.api.leggo.org.br',
   twitterAPIUrl: 'https://leggo-twitter.herokuapp.com',
   perfilUrl: 'https://perfil.parlametria.org.br/api'
 };


### PR DESCRIPTION
## Mudanças

- Altera campo que considera valor da pressão no Twitter;
- Adiciona processamento para considerar apenas uma casa decimal.

**OBS:** É necessário estar com o leggo-backend nesta [versão](https://github.com/parlametria/leggo-backend/pull/375).