### PR TITLE
Altera filtro de ações legislativas do gráfico de temperatura

### DIFF
--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.html
@@ -11,11 +11,14 @@
         Semana de {{ getSemanaString(filtro?.data) }}
       </div>
       <div class="mb-3">
-        <p>
+        <p *ngIf="filtro?.valorTemperatura !== null">
           <strong class="color-temperatura">
             {{ filtro?.valorTemperatura | number : '1.0-1' }}°C
           </strong>
           de temperatura
+        </p>
+        <p *ngIf="filtro?.valorTemperatura === null">
+          Dados de <strong class="color-temperatura">temperatura</strong> não disponíveis
         </p>
       </div>
       <p *ngIf="filtro?.valorPressao !== null">

--- a/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/temperatura-pressao/temperatura-pressao.component.ts
@@ -55,8 +55,8 @@ export class TemperaturaPressaoComponent implements OnInit {
   }
 
   getSemanaString(data) {
-    const dataInicial = data.clone().subtract(7, 'days');
-    const dataFinal = data.clone();
+    const dataInicial = data.clone();
+    const dataFinal = data.clone().add(7, 'days');
     return `${dataInicial.format('D')} de ${dataInicial.format('MMM')} a
       ${dataFinal.format('D')} de ${dataFinal.format('MMM')}`;
   }

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -164,14 +164,10 @@ export class VisTemperaturaPressaoComponent implements OnInit {
         a.popularity = parseFloat(a.popularity.toFixed(1));
         return a;
       });
-      let temperatura: any = data[1];
+      const temperatura: any = data[1];
       const temperaturaMax: any = data[2];
       let temperaturaPressao;
       if (pressao.length > temperatura.length) {
-        temperatura = data[1].map(a => {
-          a.periodo = moment(a.periodo).add(7, 'days').format('YYYY-MM-DD');
-          return a;
-        });
         temperaturaPressao = pressao.map(a => ({
           data: moment(this.getProperty(temperatura.find(p => a.date === p.periodo),
             'periodo') ?? a.date),
@@ -182,7 +178,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
       } else {
         temperaturaPressao = temperatura.map(a => ({
           data: moment(this.getProperty(pressao.find(p => a.periodo === p.date),
-            'date') ?? a.periodo).add(7, 'days'),
+            'date') ?? a.periodo),
           valorTemperatura: a.temperatura_recente,
           valorPressao: this.getProperty(pressao.find(p => a.periodo === p.date),
             'popularity') ?? null

--- a/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
+++ b/src/app/proposicoes/detalhes-proposicao/vis-temperatura-pressao/vis-temperatura-pressao.component.ts
@@ -172,7 +172,7 @@ export class VisTemperaturaPressaoComponent implements OnInit {
           data: moment(this.getProperty(temperatura.find(p => a.date === p.periodo),
             'periodo') ?? a.date),
           valorTemperatura: this.getProperty(temperatura.find(p => a.date === p.periodo),
-            'temperatura_recente') ?? 0,
+            'temperatura_recente') ?? null,
           valorPressao: a.popularity
         }));
       } else {

--- a/src/app/shared/functions/utils.ts
+++ b/src/app/shared/functions/utils.ts
@@ -1,0 +1,6 @@
+export function setUpperBound(valor: number, valorMax: number = 100) {
+  if (valor > valorMax) {
+    return valorMax;
+  }
+  return valor;
+}

--- a/src/app/shared/services/eventos.service.ts
+++ b/src/app/shared/services/eventos.service.ts
@@ -47,8 +47,7 @@ export class EventosService {
   filtrar(eventos, filtro) {
     if (typeof filtro !== 'undefined' && filtro.data) {
       const dataComparativaInicial = filtro.data.clone();
-      dataComparativaInicial.subtract(7, 'days');
-      const dataComparativaFinal = filtro.data.clone();
+      const dataComparativaFinal = filtro.data.clone().add(7, 'days');
 
       const filtrados = eventos.filter(evento => {
         return (moment(evento.data).isSameOrAfter(dataComparativaInicial) && moment(evento.data).isBefore(dataComparativaFinal));

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -8,6 +8,8 @@ import { LocalProposicao, ProposicaoLista } from '../models/proposicao.model';
 import { PressaoService } from './pressao.service';
 import { ProgressoService } from './progresso.service';
 
+import { setUpperBound } from '../functions/utils';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -106,18 +108,18 @@ export class ProposicoesListaService {
         const progressos = this.processaProgresso(progresso);
 
         const proposicoesLista = proposicoes.map(a => ({
-          ultima_temperatura: this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
-            'ultima_temperatura'),
-          temp_quinze_dias: this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
-            'temp_quinze_dias'),
-          ultima_pressao: this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
-            'ultima_pressao'),
-          pressao_oito_dias: this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
-            'pressao_oito_dias'),
+          ultima_temperatura: setUpperBound(this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
+            'ultima_temperatura')),
+          temp_quinze_dias: setUpperBound(this.getProperty(ultimaTemperatura.find(p => a.id_leggo === p.id_leggo),
+            'temp_quinze_dias')),
+          ultima_pressao: setUpperBound(this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
+            'ultima_pressao')),
+          pressao_oito_dias: setUpperBound(this.getProperty(ultimaPressao.find(p => a.id_leggo === p.id_leggo),
+            'pressao_oito_dias')),
           anotacao_data_ultima_modificacao: this.getProperty(dataUltimoInsight.find(p => a.id_leggo === p.id_leggo),
             'anotacao_data_ultima_modificacao'),
           resumo_progresso: progressos[a.id_leggo],
-          max_temperatura_interesse: maxTemperaturaInteresse.max_temperatura_periodo,
+          max_temperatura_interesse: setUpperBound(maxTemperaturaInteresse.max_temperatura_periodo),
           isDestaque: this.isDestaque(a),
           ...a
         }));


### PR DESCRIPTION
## Mudanças

- Altera o filtro de ações legislativas para considerar o valor do gráfico como data inicial do filtro e não a final; isso reflete na adição de 7 dias nos dados de temperatura, que não será mais necessário;
- Adiciona texto na tooltip quando não há temperatura.