### PR TITLE
588 correcoes bugs criticos

### DIFF
--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.scss
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.scss
@@ -54,7 +54,7 @@ $size: 13px;
         &:not(:last-child) {
           .line-between-divs {
             border: 1px solid #b0b6ba;
-            width: 30px;
+            width: 1rem;
           }
         }
       }

--- a/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
+++ b/src/app/proposicoes/card-proposicao/card-proposicao.component.ts
@@ -19,9 +19,12 @@ export class CardProposicaoComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {
+    /*
     this.proposicao.resumo_progresso = this.resumirFases(
       this.ordenaProgresso(this.proposicao.resumo_progresso)
     );
+    */
+    this.proposicao.resumo_progresso = this.ordenaProgresso(this.proposicao.resumo_progresso);
   }
 
   temasResumido(temas) {

--- a/src/app/shared/functions/process_progresso.function.ts
+++ b/src/app/shared/functions/process_progresso.function.ts
@@ -1,46 +1,66 @@
-export function ordenaProgressoProposicao(resumoProgresso) {
+import { ProgressoProposicao } from 'src/app/shared/models/proposicoes/progressoProposicao.model';
+
+export function ordenaProgressoProposicao(
+  resumoProgresso: ProgressoProposicao[]
+) {
+  if (!resumoProgresso) {
+    return resumoProgresso;
+  }
+
   let ORDER = [
     'Comissão Mista',
     'Câmara dos Deputados',
     'Senado Federal',
     'Câmara dos Deputados - Revisão',
-    'Sanção Presidencial/Promulgação'
+    'Sanção Presidencial/Promulgação',
   ];
 
-  if (resumoProgresso) {
-    if (resumoProgresso.length && resumoProgresso[0].is_mpv === false) {
-      ORDER = [
-        'Construção-Comissões',
-        'Construção-Plenário',
-        'Revisão I-Comissões',
-        'Revisão I-Plenário',
-        'Revisão II-Comissões',
-        'Revisão II-Plenário',
-        'Promulgação/Veto-Presidência da República',
-        'Sanção/Veto-Presidência da República',
-        'Avaliação dos Vetos-Congresso'
-      ];
+  if (resumoProgresso.length && resumoProgresso[0].is_mpv === false) {
+    ORDER = [
+      'Construção-Comissões',
+      'Construção-Plenário',
+      'Revisão I-Comissões',
+      'Revisão I-Plenário',
+      'Revisão II-Comissões',
+      'Revisão II-Plenário',
+      'Promulgação/Veto-Presidência da República',
+      'Sanção/Veto-Presidência da República',
+      'Avaliação dos Vetos-Congresso',
+    ];
 
-      resumoProgresso = resumoProgresso.map((r) => {
-        r.fase_global_local = r.fase_global + '-' + r.local;
-        return r;
-      });
-
-      resumoProgresso.sort((a, b) => {
-        return ORDER.indexOf(a.fase_global_local) - ORDER.indexOf(b.fase_global_local);
-      });
-    } else {
-      resumoProgresso.sort((a, b) => {
-        return ORDER.indexOf(a.fase_global) - ORDER.indexOf(b.fase_global);
-      });
-    }
-    resumoProgresso = resumoProgresso.map((r, i, l) => {
-      if (i % 2 && i < 6) {
-        r.local_casa = l[i - 1].local_casa;
-      }
+    resumoProgresso = resumoProgresso.map((r) => {
+      r.fase_global_local = r.fase_global + '-' + r.local;
       return r;
     });
+
+    resumoProgresso.sort(
+      (a, b) =>
+        ORDER.indexOf(a.fase_global_local) - ORDER.indexOf(b.fase_global_local)
+    );
+  } else {
+    resumoProgresso.sort(
+      (a, b) => ORDER.indexOf(a.fase_global) - ORDER.indexOf(b.fase_global)
+    );
   }
+
+  /*
+  resumoProgresso = resumoProgresso.map((r, i, l) => {
+    if (i % 2 && i < 6) {
+      r.local_casa = l[i - 1].local_casa;
+    }
+    return r;
+  });
+  */
+  // senado 1, 2, 5, 6
+  // camara 3, 4
+  const LOCAL_CASA_SENADO_ORDER = [0, 1, 4, 6];
+  resumoProgresso = resumoProgresso.map((r, i, l) => {
+    if (i < 6) {
+      r.local_casa = LOCAL_CASA_SENADO_ORDER.includes(i) ? 'senado' : 'camara';
+    }
+
+    return r;
+  });
 
   return resumoProgresso;
 }
@@ -48,13 +68,15 @@ export function ordenaProgressoProposicao(resumoProgresso) {
 export function resumirFasesProgresso(fases) {
   if (fases) {
     // Caso alguma fase da Revisão II tenha sido iniciada
-    const showRevisao2 = fases.some(fase => fase.fase_global.indexOf('II') !== -1 && fase.data_inicio);
+    const showRevisao2 = fases.some(
+      (fase) => fase.fase_global.indexOf('II') !== -1 && fase.data_inicio
+    );
     if (showRevisao2) {
       // Mostra todas as fases
       return fases;
     } else {
       // Não mostra Revisão II
-      return fases.filter(fase => fase.fase_global.indexOf('II') === -1);
+      return fases.filter((fase) => fase.fase_global.indexOf('II') === -1);
     }
   }
   return fases;

--- a/src/app/shared/functions/process_progresso.function.ts
+++ b/src/app/shared/functions/process_progresso.function.ts
@@ -1,66 +1,46 @@
-import { ProgressoProposicao } from 'src/app/shared/models/proposicoes/progressoProposicao.model';
-
-export function ordenaProgressoProposicao(
-  resumoProgresso: ProgressoProposicao[]
-) {
-  if (!resumoProgresso) {
-    return resumoProgresso;
-  }
-
+export function ordenaProgressoProposicao(resumoProgresso) {
   let ORDER = [
     'Comissão Mista',
     'Câmara dos Deputados',
     'Senado Federal',
     'Câmara dos Deputados - Revisão',
-    'Sanção Presidencial/Promulgação',
+    'Sanção Presidencial/Promulgação'
   ];
 
-  if (resumoProgresso.length && resumoProgresso[0].is_mpv === false) {
-    ORDER = [
-      'Construção-Comissões',
-      'Construção-Plenário',
-      'Revisão I-Comissões',
-      'Revisão I-Plenário',
-      'Revisão II-Comissões',
-      'Revisão II-Plenário',
-      'Promulgação/Veto-Presidência da República',
-      'Sanção/Veto-Presidência da República',
-      'Avaliação dos Vetos-Congresso',
-    ];
+  if (resumoProgresso) {
+    if (resumoProgresso.length && resumoProgresso[0].is_mpv === false) {
+      ORDER = [
+        'Construção-Comissões',
+        'Construção-Plenário',
+        'Revisão I-Comissões',
+        'Revisão I-Plenário',
+        'Revisão II-Comissões',
+        'Revisão II-Plenário',
+        'Promulgação/Veto-Presidência da República',
+        'Sanção/Veto-Presidência da República',
+        'Avaliação dos Vetos-Congresso'
+      ];
 
-    resumoProgresso = resumoProgresso.map((r) => {
-      r.fase_global_local = r.fase_global + '-' + r.local;
+      resumoProgresso = resumoProgresso.map((r) => {
+        r.fase_global_local = r.fase_global + '-' + r.local;
+        return r;
+      });
+
+      resumoProgresso.sort((a, b) => {
+        return ORDER.indexOf(a.fase_global_local) - ORDER.indexOf(b.fase_global_local);
+      });
+    } else {
+      resumoProgresso.sort((a, b) => {
+        return ORDER.indexOf(a.fase_global) - ORDER.indexOf(b.fase_global);
+      });
+    }
+    resumoProgresso = resumoProgresso.map((r, i, l) => {
+      if (i % 2 && i < 6) {
+        r.local_casa = l[i - 1].local_casa;
+      }
       return r;
     });
-
-    resumoProgresso.sort(
-      (a, b) =>
-        ORDER.indexOf(a.fase_global_local) - ORDER.indexOf(b.fase_global_local)
-    );
-  } else {
-    resumoProgresso.sort(
-      (a, b) => ORDER.indexOf(a.fase_global) - ORDER.indexOf(b.fase_global)
-    );
   }
-
-  /*
-  resumoProgresso = resumoProgresso.map((r, i, l) => {
-    if (i % 2 && i < 6) {
-      r.local_casa = l[i - 1].local_casa;
-    }
-    return r;
-  });
-  */
-  // senado 1, 2, 5, 6
-  // camara 3, 4
-  const LOCAL_CASA_SENADO_ORDER = [0, 1, 4, 6];
-  resumoProgresso = resumoProgresso.map((r, i, l) => {
-    if (i < 6) {
-      r.local_casa = LOCAL_CASA_SENADO_ORDER.includes(i) ? 'senado' : 'camara';
-    }
-
-    return r;
-  });
 
   return resumoProgresso;
 }
@@ -68,15 +48,13 @@ export function ordenaProgressoProposicao(
 export function resumirFasesProgresso(fases) {
   if (fases) {
     // Caso alguma fase da Revisão II tenha sido iniciada
-    const showRevisao2 = fases.some(
-      (fase) => fase.fase_global.indexOf('II') !== -1 && fase.data_inicio
-    );
+    const showRevisao2 = fases.some(fase => fase.fase_global.indexOf('II') !== -1 && fase.data_inicio);
     if (showRevisao2) {
       // Mostra todas as fases
       return fases;
     } else {
       // Não mostra Revisão II
-      return fases.filter((fase) => fase.fase_global.indexOf('II') === -1);
+      return fases.filter(fase => fase.fase_global.indexOf('II') === -1);
     }
   }
   return fases;

--- a/src/app/shared/models/proposicoes/progressoProposicao.model.ts
+++ b/src/app/shared/models/proposicoes/progressoProposicao.model.ts
@@ -1,6 +1,7 @@
 export interface ProgressoProposicao {
   id_leggo: string;
   fase_global: string;
+  fase_global_local?: string;
   local: string;
   data_inicio: Date;
   data_fim: Date;

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -163,7 +163,7 @@ export class ProposicoesListaService {
   }
 
   private isAprovadaEmUmaCasa(prop: ProposicaoLista) {
-    if (typeof prop.destaques == 'undefined' || prop.destaques.length === 0) {
+    if (typeof prop.destaques === 'undefined' || prop.destaques.length === 0) {
       return false;
     }
 
@@ -306,7 +306,7 @@ export class ProposicoesListaService {
   private processaFase(progresso: Array<any>, isAprovadaEmUmaCasa: boolean) {
     const faseTramitacao = ['Iniciadora', 'Revisora', 'Sanção/Veto'];
 
-    if(isAprovadaEmUmaCasa) {
+    if (isAprovadaEmUmaCasa) {
       return faseTramitacao[1];
     }
 

--- a/src/app/shared/services/proposicoes-lista.service.ts
+++ b/src/app/shared/services/proposicoes-lista.service.ts
@@ -122,7 +122,7 @@ export class ProposicoesListaService {
           resumo_progresso: progressos[a.id_leggo],
           max_temperatura_interesse: setUpperBound(maxTemperaturaInteresse.max_temperatura_periodo),
           isDestaque: this.isDestaque(a),
-          fase: this.processaFase(progressos[a.id_leggo]),
+          fase: this.processaFase(progressos[a.id_leggo], this.isAprovadaEmUmaCasa(a)),
           ...a
         }));
 
@@ -160,6 +160,14 @@ export class ProposicoesListaService {
     } else {
       return objeto[property];
     }
+  }
+
+  private isAprovadaEmUmaCasa(prop: ProposicaoLista) {
+    if (typeof prop.destaques == 'undefined' || prop.destaques.length === 0) {
+      return false;
+    }
+
+    return prop.destaques[0].criterio_aprovada_em_uma_casa;
   }
 
   private isDestaque(prop: ProposicaoLista) {
@@ -295,12 +303,18 @@ export class ProposicoesListaService {
     return false;
   }
 
-  private processaFase(progresso: Array<any>) {
-    let fase = 0;
+  private processaFase(progresso: Array<any>, isAprovadaEmUmaCasa: boolean) {
     const faseTramitacao = ['Iniciadora', 'Revisora', 'Sanção/Veto'];
+
+    if(isAprovadaEmUmaCasa) {
+      return faseTramitacao[1];
+    }
+
     if (!progresso) {
       return '';
     }
+
+    let fase = 0;
     progresso.forEach(pfase => {
       if (pfase.data_inicio && pfase.data_fim || pfase.pulou === true) {
         fase += 1;


### PR DESCRIPTION
Esse PR aplica as correções indicadas na issue [588](https://github.com/parlametria/leggo-frontend/issues/588):
- [x] Proposições aparecem na etapa errada no painel dos alertas do ineresse. Proposições com a descrição "Aprovada em uma casa" deveriam aparecer na etapa de revisão.
- [ ] Tramitação com casas repetidas: https://parlametria.org.br/proposicoes/40ccf3c29d8d8c799dd114d48ab95c6b/temperatura-pressao?interesse=socioambiental a sequência precisa ser Senado 1,2 Câmara 3,4 e Senado 5,6
- [x] Componente de etapas de Tramitação com 6 passos na home, são 8 passos

## Issues
- https://github.com/parlametria/leggo-frontend/issues/588
