### PR TITLE
bugfix: Corrige número de senadores exibido

### DIFF
--- a/src/app/atividade-parlamentar/atividade-parlamentar.component.html
+++ b/src/app/atividade-parlamentar/atividade-parlamentar.component.html
@@ -75,7 +75,7 @@
           </div>
         </div>
         <div class="col-md-3">
-          <app-filtro-lateral [casa]="casa"></app-filtro-lateral>
+          <app-filtro-lateral [casa]="casa" [totalParlamentares]="parlamentares?.length || 0"></app-filtro-lateral>
         </div>
       </div>
       <pagination-template

--- a/src/app/atividade-parlamentar/filtro-lateral/filtro-lateral.component.ts
+++ b/src/app/atividade-parlamentar/filtro-lateral/filtro-lateral.component.ts
@@ -18,6 +18,7 @@ import { FiltroLateralService } from './filtro-lateral.service';
 })
 export class FiltroLateralComponent implements OnInit, AfterContentInit, OnDestroy {
   @Input() interesse: string;
+  @Input() totalParlamentares: number;
   @Input() casa: 'senado' | 'camara';
   // @Output() filterChange = new EventEmitter<any>();
 
@@ -28,10 +29,6 @@ export class FiltroLateralComponent implements OnInit, AfterContentInit, OnDestr
   public temaSelecionado: string;
   public casaSelecionada: string;
   public orderBySelecionado: string;
-
-  get totalParlamentares(): number {
-    return this.casa === 'senado' ? 80 : 513;
-  }
 
   numeroProposicoes: number;
 


### PR DESCRIPTION
Esse PR corrige um bug em que no filtro é indicado 80 senadores quando estes são 81. Olhando o retorno da API, ela está retornando 81 senadores, sendo assim, esse PR utiliza o "length" do vetor de parlamentares para indicar a quantidade.
